### PR TITLE
Change events API to be static

### DIFF
--- a/src/aldente.cpp
+++ b/src/aldente.cpp
@@ -287,13 +287,13 @@ void Aldente::handle_movement()
     const unsigned char* btns =
         glfwGetJoystickButtons(GLFW_JOYSTICK_1, &btn_c);
 
-    if (keys[GLFW_KEY_W] || btns && btns[13])
+    if (keys[GLFW_KEY_W] || (btns && btns[13]))
         displacement += cam_step * camera->cam_front;
-    if (keys[GLFW_KEY_S] || btns && btns[15])
+    if (keys[GLFW_KEY_S] || (btns && btns[15]))
         displacement -= cam_step * camera->cam_front;
-    if (keys[GLFW_KEY_A] || btns && btns[16])
+    if (keys[GLFW_KEY_A] || (btns && btns[16]))
         displacement -= glm::normalize(glm::cross(camera->cam_front, camera->cam_up)) * cam_step;
-    if (keys[GLFW_KEY_D] || btns && btns[14])
+    if (keys[GLFW_KEY_D] || (btns && btns[14]))
         displacement += glm::normalize(glm::cross(camera->cam_front, camera->cam_up)) * cam_step;
     if (keys[GLFW_KEY_SPACE])
         displacement += cam_step * camera->cam_up;
@@ -321,7 +321,7 @@ void Aldente::setup_callbacks()
     glfwSetScrollCallback(window, scroll_callback);
     glfwSetFramebufferSizeCallback(window, resize_callback);
 
-    events::InputEvent.subscribe(&print_input_event);
+    events::InputEvent::subscribe(&print_input_event);
 }
 
 void Aldente::setup_opengl()

--- a/src/events/event.h
+++ b/src/events/event.h
@@ -14,25 +14,29 @@ private:
   typedef void (*cb_t)(T);
 
   // The internal vector of event callbacks.
-  std::unordered_set<cb_t> callbacks;
+  static std::unordered_set<cb_t> callbacks;
 
 public:
   // Subscribes `cb` to this event.
-  void subscribe(cb_t cb) {
+  static void subscribe(cb_t cb) {
     callbacks.insert(cb);
   }
 
   // Unsubscribes `cb` to this event.
-  void unsubscribe(cb_t cb) {
+  static void unsubscribe(cb_t cb) {
     callbacks.erase(cb);
   }
 
   // Dispatches an event with payload `data`.
-  void dispatch(T data) {
+  static void dispatch(T data) {
     for (cb_t cb : callbacks)
       (*cb)(data);
   }
 };
+
+template<class T>
+std::unordered_set<void (*)(T)> Event<T>::callbacks =
+  std::unordered_set<void (*)(T)>();
 
 }
 }

--- a/src/events/input.cpp
+++ b/src/events/input.cpp
@@ -1,9 +1,0 @@
-#include "events/input.h"
-
-namespace kuuhaku {
-namespace events {
-
-Event<InputData> InputEvent;
-
-}
-}

--- a/src/events/input.h
+++ b/src/events/input.h
@@ -12,7 +12,8 @@ struct InputData {
   int level; // If button, zero is not pressed, nonzero is pressed.
              // Otherwise, is axis analog level.
 };
-extern Event<InputData> InputEvent;
+// A joystick input.
+class InputEvent : public Event<InputData> {};
 
 }
 }

--- a/src/input/process.cpp
+++ b/src/input/process.cpp
@@ -19,7 +19,7 @@ void process() {
       const bool same = p_btns[i] == btns[i];
       p_btns[i] = btns[i];
       if (!same) {
-        events::InputEvent.dispatch({
+        events::InputEvent::dispatch({
           .joystick = 1,
           .is_button = true,
           .which = i,
@@ -39,7 +39,7 @@ void process() {
       const bool same = p_axes[i] == level;
       p_axes[i] = level;
       if (!same) {
-        events::InputEvent.dispatch({
+        events::InputEvent::dispatch({
           .joystick = 1,
           .is_button = false,
           .which = i,


### PR DESCRIPTION
This reduces boilerplate (no need for `events/*.cpp`) and opens up the possibility for adding event logging later on.