### PR TITLE
use stateless lambda, rename input -> joystick

### DIFF
--- a/src/aldente.cpp
+++ b/src/aldente.cpp
@@ -311,14 +311,14 @@ void Aldente::setup_callbacks()
     glfwSetScrollCallback(window, scroll_callback);
     glfwSetFramebufferSizeCallback(window, resize_callback);
 
-    events::InputEvent::subscribe([](events::InputData d) {
+    events::JoystickEvent::subscribe([](events::JoystickData d) {
         fprintf(stderr,
-                "InputEvent:\n"
-                "  joystick: %d\n"
+                "JoystickEvent:\n"
+                "  id: %d\n"
                 "  is_button: %d\n"
-                "  which: %d\n"
-                "  level: %d\n",
-                d.joystick, d.is_button, d.which, d.level);
+                "  input: %d\n"
+                "  state: %d\n",
+                d.id, d.is_button, d.input, d.state);
     });
 }
 

--- a/src/aldente.cpp
+++ b/src/aldente.cpp
@@ -302,16 +302,6 @@ void Aldente::handle_movement()
     camera->recalculate();
 }
 
-void print_input_event(events::InputData d) {
-    fprintf(stderr,
-            "InputEvent:\n"
-            "  joystick: %d\n"
-            "  is_button: %d\n"
-            "  which: %d\n"
-            "  level: %d\n",
-            d.joystick, d.is_button, d.which, d.level);
-}
-
 void Aldente::setup_callbacks()
 {
     glfwSetErrorCallback(error_callback);
@@ -321,7 +311,15 @@ void Aldente::setup_callbacks()
     glfwSetScrollCallback(window, scroll_callback);
     glfwSetFramebufferSizeCallback(window, resize_callback);
 
-    events::InputEvent::subscribe(&print_input_event);
+    events::InputEvent::subscribe([](events::InputData d) {
+        fprintf(stderr,
+                "InputEvent:\n"
+                "  joystick: %d\n"
+                "  is_button: %d\n"
+                "  which: %d\n"
+                "  level: %d\n",
+                d.joystick, d.is_button, d.which, d.level);
+    });
 }
 
 void Aldente::setup_opengl()

--- a/src/events/event.h
+++ b/src/events/event.h
@@ -18,6 +18,7 @@ private:
 
 public:
   // Subscribes `cb` to this event.
+  // It's possible to use a stateless lambda here.
   static void subscribe(cb_t cb) {
     callbacks.insert(cb);
   }

--- a/src/events/input.h
+++ b/src/events/input.h
@@ -5,15 +5,15 @@ namespace kuuhaku {
 namespace events {
 
 const int INPUT_ANALOG_LEVELS = 5;
-struct InputData {
-  int joystick;
+struct JoystickData {
+  int id; // Which joystick
   bool is_button;
-  int which; // Button or axis number
-  int level; // If button, zero is not pressed, nonzero is pressed.
+  int input; // Button or axis number
+  int state; // If button, zero is not pressed, nonzero is pressed.
              // Otherwise, is axis analog level.
 };
 // A joystick input.
-class InputEvent : public Event<InputData> {};
+class JoystickEvent : public Event<JoystickData> {};
 
 }
 }

--- a/src/input/process.cpp
+++ b/src/input/process.cpp
@@ -19,12 +19,12 @@ void process() {
       const bool same = p_btns[i] == btns[i];
       p_btns[i] = btns[i];
       if (!same) {
-        events::InputData d;
-        d.joystick = 1;
+        events::JoystickData d;
+        d.id = 1;
         d.is_button = true;
-        d.which = i;
-        d.level = btns[i] == GLFW_PRESS;
-        events::InputEvent::dispatch(d);
+        d.input = i;
+        d.state = btns[i] == GLFW_PRESS;
+        events::JoystickEvent::dispatch(d);
       }
     }
   }
@@ -39,12 +39,12 @@ void process() {
       const bool same = p_axes[i] == level;
       p_axes[i] = level;
       if (!same) {
-        events::InputData d;
-        d.joystick = 1;
+        events::JoystickData d;
+        d.id = 1;
         d.is_button = false;
-        d.which = i;
-        d.level = level;
-        events::InputEvent::dispatch(d);
+        d.input = i;
+        d.state = level;
+        events::JoystickEvent::dispatch(d);
       }
     }
   }


### PR DESCRIPTION
Update usage of subscribe so people will use stateless lambdas for callbacks.

Also tacking on a rename refactor: input -> joystick, since these events are only concerned with joysticks.