### PR TITLE
Geometry cleanup

### DIFF
--- a/shaders/basic/vert.glsl
+++ b/shaders/basic/vert.glsl
@@ -12,13 +12,13 @@ uniform mat4 model;
 uniform mat4 view;
 uniform mat4 projection;
 uniform mat4 light_matrix;
-uniform mat4 mesh_model;
+//uniform mat4 mesh_model;
 
 void main()
 {
-    gl_Position = projection * view * model * mesh_model * vec4(position, 1.0f);
-    frag_pos = vec3(model * mesh_model * vec4(position, 1.0f));
-    frag_normal = mat3(transpose(inverse(model * mesh_model))) * normal;
+    gl_Position = projection * view * model * vec4(position, 1.0f);
+    frag_pos = vec3(model * vec4(position, 1.0f));
+    frag_normal = mat3(transpose(inverse(model))) * normal;
 	frag_pos_light = light_matrix * vec4(frag_pos, 1.0);
 	frag_tex_coord = vec2(tex_coord.x, 1.0 - tex_coord.y); //y-axis usually requires inverting
 }

--- a/src/asset_loader.h
+++ b/src/asset_loader.h
@@ -2,7 +2,7 @@
 
 #include "scene/scene.h"
 #include "model/model.h"
-#include "soil.h"
+#include "SOIL.h"
 
 #include <assimp/Importer.hpp>
 #include <assimp/scene.h>

--- a/src/model/geometry.cpp
+++ b/src/model/geometry.cpp
@@ -2,12 +2,9 @@
 #include "SOIL.h"
 
 Geometry::Geometry(GLenum draw, GLint wrap, GLint filter) :
-        draw_type(draw), 
-        wrap_type(wrap), 
+        draw_type(draw),
+        wrap_type(wrap),
         filter_type(filter){
-    has_texture = false;
-    has_normals = true;
-
     glGenVertexArrays(1, &VAO);
     glGenBuffers(1, &VBO);
     glGenBuffers(1, &NBO);
@@ -25,19 +22,15 @@ void Geometry::populate_buffers() {
     glEnableVertexAttribArray(0);
     glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, 0);
 
-    if (has_normals) {
-        glBindBuffer(GL_ARRAY_BUFFER, NBO);
-        glBufferData(GL_ARRAY_BUFFER, sizeof(glm::vec3) * normals.size(), normals.data(), GL_STATIC_DRAW);
-        glEnableVertexAttribArray(1);
-        glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 0, 0);
-    }
+    glBindBuffer(GL_ARRAY_BUFFER, NBO);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(glm::vec3) * normals.size(), normals.data(), GL_STATIC_DRAW);
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 0, 0);
 
-    if (has_texture) {
-        glBindBuffer(GL_ARRAY_BUFFER, TBO);
-        glBufferData(GL_ARRAY_BUFFER, sizeof(glm::vec2) * tex_coords.size(), tex_coords.data(), GL_STATIC_DRAW);
-        glEnableVertexAttribArray(2);
-        glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, 0, 0);
-    }
+    glBindBuffer(GL_ARRAY_BUFFER, TBO);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(glm::vec2) * tex_coords.size(), tex_coords.data(), GL_STATIC_DRAW);
+    glEnableVertexAttribArray(2);
+    glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, 0, 0);
 
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, EBO);
     glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLuint) * indices.size(), indices.data(), GL_STATIC_DRAW);
@@ -47,8 +40,6 @@ void Geometry::populate_buffers() {
 }
 /*
 void Geometry::attachNewTexture(const char *texture_loc) {
-    has_texture = true;
-
     glGenTextures(1, &texture);
 
     glBindTexture(GL_TEXTURE_2D, texture);

--- a/src/model/geometry.cpp
+++ b/src/model/geometry.cpp
@@ -38,29 +38,13 @@ void Geometry::populate_buffers() {
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glBindVertexArray(0);
 }
-/*
-void Geometry::attachNewTexture(const char *texture_loc) {
-    glGenTextures(1, &texture);
 
-    glBindTexture(GL_TEXTURE_2D, texture);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, wrap_type);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, wrap_type);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter_type);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter_type);
-
-    int width, height, channels;
-    unsigned char *image = SOIL_load_image(texture_loc, &width, &height, &channels, SOIL_LOAD_RGB);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, image);
-    glGenerateMipmap(GL_TEXTURE_2D);
-    SOIL_free_image_data(image);
-    glBindTexture(GL_TEXTURE_2D, 0);
-}*/
-
-void Geometry::attachTexture(GLuint toAttach) {
-    texture = toAttach;
+void Geometry::attach_texture(GLuint tex_id) {
+    texture = tex_id;
+    has_texture = true;
 }
 
-GLuint Geometry::getTextureGL() {
+GLuint Geometry::get_texture() {
     return texture;
 }
 

--- a/src/model/geometry.h
+++ b/src/model/geometry.h
@@ -7,7 +7,6 @@
 class Geometry {
 public:
     bool has_texture;
-    bool has_normals;
     GLuint texture;
     std::vector<glm::vec3> vertices;
     std::vector<glm::vec3> normals;
@@ -26,9 +25,9 @@ public:
 
     void populate_buffers();
 
-    void attachTexture(GLuint texture);
+    void attach_texture(GLuint tex_id);
 
-    GLuint getTextureGL();
+    GLuint get_texture();
 
     void draw();
 

--- a/src/model/geometry_generator.cpp
+++ b/src/model/geometry_generator.cpp
@@ -7,7 +7,7 @@ void GeometryGenerator::destroy() {
         delete (*it);
 }
 
-Geometry *GeometryGenerator::generate_cube(GLfloat scale, bool has_normals) {
+Geometry *GeometryGenerator::generate_cube(GLfloat scale) {
     Geometry *cube = new Geometry();
 
     glm::vec3 v0 = {scale / 2.f, scale / 2.f, scale / 2.f};
@@ -61,25 +61,22 @@ Geometry *GeometryGenerator::generate_cube(GLfloat scale, bool has_normals) {
     cube->vertices.push_back(v7);
     cube->vertices.push_back(v6);
 
-    if (has_normals) {
-        for (int i = 0; i < 6; ++i)
-            cube->normals.push_back(glm::vec3(0.f, 1.f, 0.f));
-        for (int i = 0; i < 6; ++i)
-            cube->normals.push_back(glm::vec3(0.f, 0.f, -1.f));
-        for (int i = 0; i < 6; ++i)
-            cube->normals.push_back(glm::vec3(-1.f, 0.f, 0.f));
-        for (int i = 0; i < 6; ++i)
-            cube->normals.push_back(glm::vec3(1.f, 0.f, 0.f));
-        for (int i = 0; i < 6; ++i)
-            cube->normals.push_back(glm::vec3(0.f, 0.f, 1.f));
-        for (int i = 0; i < 6; ++i)
-            cube->normals.push_back(glm::vec3(0.f, -1.f, 0.f));
-    }
+    for (int i = 0; i < 6; ++i)
+        cube->normals.push_back(glm::vec3(0.f, 1.f, 0.f));
+    for (int i = 0; i < 6; ++i)
+        cube->normals.push_back(glm::vec3(0.f, 0.f, -1.f));
+    for (int i = 0; i < 6; ++i)
+        cube->normals.push_back(glm::vec3(-1.f, 0.f, 0.f));
+    for (int i = 0; i < 6; ++i)
+        cube->normals.push_back(glm::vec3(1.f, 0.f, 0.f));
+    for (int i = 0; i < 6; ++i)
+        cube->normals.push_back(glm::vec3(0.f, 0.f, 1.f));
+    for (int i = 0; i < 6; ++i)
+        cube->normals.push_back(glm::vec3(0.f, -1.f, 0.f));
 
     for (int i = 0; i < cube->vertices.size(); ++i)
         cube->indices.push_back(i);
 
-    cube->has_normals = has_normals;
     cube->populate_buffers();
     geometries.push_back(cube);
     return cube;
@@ -199,7 +196,6 @@ Geometry *GeometryGenerator::generate_cylinder(GLfloat radius, GLfloat height, G
             v3 = {radius * cos(theta + step), 0, radius * sinf(theta + step)};
         }
 
-
         //Top Portion
         cylinder->vertices.push_back(v_top);
         cylinder->vertices.push_back(v1);
@@ -242,7 +238,7 @@ Geometry *GeometryGenerator::generate_cylinder(GLfloat radius, GLfloat height, G
 
 }
 
-Geometry *GeometryGenerator::generate_plane(GLfloat scale, int has_texture) {
+Geometry *GeometryGenerator::generate_plane(GLfloat scale, bool has_texture) {
     Geometry *plane = new Geometry();
 
     if (has_texture) {

--- a/src/model/geometry_generator.h
+++ b/src/model/geometry_generator.h
@@ -17,11 +17,11 @@ public:
 
     static void destroy();
 
-    static Geometry *generate_cube(GLfloat scale, bool with_normals);
+    static Geometry *generate_cube(GLfloat scale);
 
     static Geometry *generate_sphere(GLfloat radius, GLuint divisions);
 
     static Geometry *generate_cylinder(GLfloat radius, GLfloat height, GLuint divisions, bool is_centered);
 
-    static Geometry *generate_plane(GLfloat scale, int texture_type);
+    static Geometry *generate_plane(GLfloat scale, bool has_texture);
 };

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -26,30 +26,3 @@ void Model::pass(Shader *s, glm::mat4 to_world) {
         }
     }
 }
-
-void Model::combine_meshes() {
-    // Stop if one or zero meshes.
-    if (meshes.size() <= 1)
-        return;
-
-    Mesh *mega_mesh = meshes.at(0);
-    Geometry *mega_geometry = new Geometry();
-    // TODO: GARBAGE COLLECT THIS PIECE OF GEOMETRY.
-    mega_mesh->geometry = mega_geometry;
-    mega_mesh->to_world = glm::mat4(1.f);
-
-    unsigned int index_offset = 0;
-    for (Mesh *mesh : meshes) {
-        for (glm::vec3 v : mesh->geometry->vertices)
-            mega_geometry->vertices.push_back(glm::vec3(mesh->to_world * glm::vec4(v, 1.f)));
-        for (glm::vec3 n : mesh->geometry->normals)
-            mega_geometry->normals.push_back(
-                    glm::normalize(glm::mat3(glm::transpose(glm::inverse(mesh->to_world))) * n));
-        for (unsigned int i : mesh->geometry->indices)
-            mega_geometry->indices.push_back(i + index_offset);
-        index_offset += (unsigned int) mesh->geometry->indices.size();
-    }
-    mega_geometry->populate_buffers();
-    meshes.clear();
-    add_mesh(mega_mesh);
-}

--- a/src/shaders/basic_shader.cpp
+++ b/src/shaders/basic_shader.cpp
@@ -36,7 +36,7 @@ void BasicShader::draw(Geometry *g, glm::mat4 to_world) {
     glUniformMatrix4fv(glGetUniformLocation(shader_id, "view"), 1, GL_FALSE, &V[0][0]);
     // Model matrix
     glUniformMatrix4fv(glGetUniformLocation(shader_id, "model"), 1, GL_FALSE, &to_world[0][0]);
-    glUniformMatrix4fv(glGetUniformLocation(shader_id, "mesh_model"), 1, GL_FALSE, &mesh_model[0][0]);
+    //glUniformMatrix4fv(glGetUniformLocation(shader_id, "mesh_model"), 1, GL_FALSE, &mesh_model[0][0]);
 
     glUniform1i(glGetUniformLocation(shader_id, "texture_enabled"), g->has_texture);
     //Bind Texture

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -57,6 +57,7 @@ void FloorTile::update(Tile *hover) {
     rigidBody->getMotionState()->getWorldTransform(t);
     transform.set_position(glm::vec3((float) t.getOrigin().getX(), (float) t.getOrigin().getY(),
                                   (float) t.getOrigin().getZ()));
+    /*
     if (hover == this) {
         Material *mat = new Material(color::windwaker_green);
         model->meshes[0]->material = mat;

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -10,7 +10,7 @@ Tile::~Tile() {}
 void Tile::draw(SceneCamera &camera) {
     if (model)
         model->draw(camera, transform.get_world_mat());
-    if (construct) 
+    if (construct)
         construct->draw(camera);
 }
 
@@ -56,8 +56,7 @@ void FloorTile::update(Tile *hover) {
     // Get the transform from Bullet and into 't'
     rigidBody->getMotionState()->getWorldTransform(t);
     transform.set_position(glm::vec3((float) t.getOrigin().getX(), (float) t.getOrigin().getY(),
-                                  (float) t.getOrigin().getZ()));    
-    /*
+                                  (float) t.getOrigin().getZ()));
     if (hover == this) {
         Material *mat = new Material(color::windwaker_green);
         model->meshes[0]->material = mat;
@@ -84,7 +83,7 @@ WallTile::WallTile(int x, int z) : Tile::Tile() {
 
     mesh->to_world = glm::mat4(1.0f);
     //mesh->to_world *= glm::translate(glm::mat4(1.f), glm::vec3(0,0,0));
-    mesh->geometry = GeometryGenerator::generate_cube(1.0f, true);
+    mesh->geometry = GeometryGenerator::generate_cube(1.0f);
     mesh->shader = ShaderManager::get_default();
     Material *mat = new Material(color::indian_red);
     mesh->material = mat;
@@ -111,8 +110,8 @@ void WallTile::update(Tile *hover) {
 
     // Get the transform from Bullet and into 't'
     rigidBody->getMotionState()->getWorldTransform(t);
-    transform.set_position(glm::vec3((float) t.getOrigin().getX(), (float) t.getOrigin().getY(), 
-        (float) t.getOrigin().getZ()));    
+    transform.set_position(glm::vec3((float) t.getOrigin().getX(), (float) t.getOrigin().getY(),
+        (float) t.getOrigin().getZ()));
     /*
     if (hover == this) {
         Material *mat = new Material(color::windwaker_green);


### PR DESCRIPTION
- Always generate buffer objects for tex coords and normals
- Removed Model::combine_meshes
- Eliminated usage of mesh_model (to be restored later)