### PR TITLE
Default flags for tcp query

### DIFF
--- a/src/net/network_client.cpp
+++ b/src/net/network_client.cpp
@@ -5,7 +5,8 @@ NetworkClient::NetworkClient(boost::asio::io_service& ios) :
 }
 
 bool NetworkClient::connect(const string& host, unsigned int port) {
-    tcp::resolver::query query(tcp::v4(), host, std::to_string(port));
+    tcp::resolver::query query(tcp::v4(), host, std::to_string(port), 
+        boost::asio::ip::resolver_query_base::flags());
     tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
     try {
         boost::asio::connect(connection.get_socket(), endpoint_iterator);


### PR DESCRIPTION
Should hopefully fix errors like 

```
terminate called after throwing an instance of 'boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::system::system_error> >'
what(): resolve: Host not found (authoritative)
```

which arise when running aldente with no internet connection on Linux (maybe Mac? idk)