### PR TITLE
Conceptual input translation layer with debug input

### DIFF
--- a/src/aldente_client.cpp
+++ b/src/aldente_client.cpp
@@ -1,6 +1,9 @@
 #include "aldente_client.h"
 
 #include "window.h"
+#include "input/num_to_button.h"
+#include "input/raw_maps/xbox.h"
+#include "input/raw_maps/debug.h"
 #include "asset_loader.h"
 #include "physics.h"
 #include "scene_manager.h"
@@ -50,6 +53,9 @@ void AldenteClient::start() {
     std::string game_name;
     Config::config->get_value(Config::str_game_name, game_name);
     Window window(game_name, true, width, height);
+
+    // Create raw input translator.
+    input::NumToButton translator(input::BTN_MAP_XBOX, input::KBD_MAP_DEBUG);
 
     // Setup subsystems after window creation.
     glSetup();

--- a/src/debug_input.cpp
+++ b/src/debug_input.cpp
@@ -187,7 +187,7 @@ DebugInput::DebugInput(Window &window, SceneManager &scene_manager, Physics &p) 
         camera->recalculate();
     });
 
-    // Test fire for joystick events
+    // Test fire for button events
     events::button_event.connect([](events::ButtonData &d) {
         fprintf(stderr,
                 "ButtonEvent:\n"

--- a/src/debug_input.cpp
+++ b/src/debug_input.cpp
@@ -188,14 +188,13 @@ DebugInput::DebugInput(Window &window, SceneManager &scene_manager, Physics &p) 
     });
 
     // Test fire for joystick events
-    events::joystick_event.connect([](events::JoystickData &d) {
-        /*fprintf(stderr,
-                "JoystickEvent:\n"
+    events::button_event.connect([](events::ButtonData &d) {
+        fprintf(stderr,
+                "ButtonEvent:\n"
                         "  id: %d\n"
-                        "  is_button: %d\n"
                         "  input: %d\n"
                         "  state: %d\n",
-                d.id, d.is_button, d.input, d.state);*/
+                d.id, d.input, d.state);
     });
 }
 

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -3,6 +3,7 @@
 namespace events {
     using boost::signals2::signal;
     signal<void(JoystickData &)> joystick_event;
+    signal<void(ButtonData &)> button_event;
     signal<void(WindowSizeData &)> window_buffer_resize_event;
     signal<void(WindowKeyData &)> window_key_event;
     signal<void(WindowCursorData &)> window_cursor_event;

--- a/src/events.h
+++ b/src/events.h
@@ -11,6 +11,8 @@ namespace events {
     using boost::signals2::signal;
 
     const int INPUT_ANALOG_LEVELS = 5;
+
+    // Raw joystick input
     struct JoystickData {
         int id; // Which joystick
         bool is_button;
@@ -19,6 +21,24 @@ namespace events {
         // Otherwise, is axis analog level.
     };
     extern signal<void(JoystickData &)> joystick_event;
+
+    // Conceptual button input
+    enum ConceptualButton {
+        BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT, // D-pad
+        BTN_A, BTN_B, BTN_X, BTN_Y, // Face buttons
+        BTN_BACK, BTN_XBOX, BTN_START, // Middle buttons
+        BTN_LB, BTN_RB, // Bumpers
+
+        AX_LV, AX_LH, AX_RV, AX_RH, // Left and right sticks, vertical and horizontal axes
+        AX_LT, AX_RT, // Left and right triggers
+    };
+    struct ButtonData {
+        int id; // Which controller
+        ConceptualButton input;
+        int state; // If button, zero is not pressed, nonzero is pressed.
+        // Otherwise, is axis analog level.
+    };
+    extern signal<void(ButtonData &)> button_event;
 
     struct WindowSizeData {
         Window *window;

--- a/src/input/num_to_button.cpp
+++ b/src/input/num_to_button.cpp
@@ -1,0 +1,25 @@
+#include "num_to_button.h"
+
+namespace input {
+    NumToButton::NumToButton(
+            const std::map<RawButton, events::ConceptualButton> &joy_map_,
+            const std::map<RawKeyboard, events::ConceptualButton> &key_map_
+    ) : joy_map(joy_map_), key_map(key_map_) {
+        events::window_key_event.connect([&](const events::WindowKeyData &d) {
+            // Ignore repeats
+            if (d.action == GLFW_REPEAT) return;
+
+            const auto &found = key_map.find({d.key, d.mods});
+            // Bail if not in mapping
+            if (found == key_map.end()) return;
+
+            // Determine level to emit
+            const int level = found->first.level;
+            const int coeff = d.action == GLFW_RELEASE ? 0 : 1;
+
+            // Emit the event with controller ID 0
+            events::ButtonData next_d = {0, found->second, level * coeff};
+            events::button_event(next_d);
+        });
+    }
+}

--- a/src/input/num_to_button.h
+++ b/src/input/num_to_button.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "events.h"
+#include "raw_maps/raw_map.h"
+
+namespace input {
+// Translation unit for numeric joypad input to conceptual button.
+class NumToButton {
+public:
+    // Sets up event listeners/dispatchers
+    NumToButton(
+            const std::map<RawButton, events::ConceptualButton> &joy_map,
+            const std::map<RawKeyboard, events::ConceptualButton> &key_map
+    );
+
+private:
+    const std::map<RawButton, events::ConceptualButton> &joy_map;
+    const std::map<RawKeyboard, events::ConceptualButton> &key_map;
+};
+}

--- a/src/input/raw_maps/debug.h
+++ b/src/input/raw_maps/debug.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <GL/glew.h>
+#include <GLFW/glfw3.h>
+
+#include "raw_map.h"
+#include "events.h"
+
+namespace input {
+    const std::map<RawKeyboard, events::ConceptualButton> KBD_MAP_DEBUG {
+            // Shift-WASD for D-Pad
+            {{GLFW_KEY_W, GLFW_MOD_SHIFT, 1}, events::BTN_UP},
+            {{GLFW_KEY_A, GLFW_MOD_SHIFT, 1}, events::BTN_LEFT},
+            {{GLFW_KEY_S, GLFW_MOD_SHIFT, 1}, events::BTN_DOWN},
+            {{GLFW_KEY_D, GLFW_MOD_SHIFT, 1}, events::BTN_RIGHT},
+
+            // HJKL for ABXY
+            {{GLFW_KEY_H, 0, 1}, events::BTN_A},
+            {{GLFW_KEY_J, 0, 1}, events::BTN_B},
+            {{GLFW_KEY_K, 0, 1}, events::BTN_X},
+            {{GLFW_KEY_L, 0, 1}, events::BTN_Y},
+
+            // YU for left shoulders, IO for right shoulders
+            {{GLFW_KEY_Y, 0, events::INPUT_ANALOG_LEVELS}, events::AX_LT},
+            {{GLFW_KEY_U, 0, 1}, events::BTN_LB},
+            {{GLFW_KEY_I, 0, 1}, events::BTN_RB},
+            {{GLFW_KEY_O, 0, events::INPUT_ANALOG_LEVELS}, events::AX_RT},
+
+            // WASD for left stick
+            {{GLFW_KEY_W, 0, -events::INPUT_ANALOG_LEVELS}, events::AX_LV},
+            {{GLFW_KEY_A, 0, -events::INPUT_ANALOG_LEVELS}, events::AX_LH},
+            {{GLFW_KEY_S, 0, events::INPUT_ANALOG_LEVELS}, events::AX_LV},
+            {{GLFW_KEY_D, 0, events::INPUT_ANALOG_LEVELS}, events::AX_LH},
+
+            // Arrow keys for right stick
+            {{GLFW_KEY_UP, 0, -events::INPUT_ANALOG_LEVELS}, events::AX_RV},
+            {{GLFW_KEY_LEFT, 0, -events::INPUT_ANALOG_LEVELS}, events::AX_RH},
+            {{GLFW_KEY_DOWN, 0, events::INPUT_ANALOG_LEVELS}, events::AX_RV},
+            {{GLFW_KEY_RIGHT, 0, events::INPUT_ANALOG_LEVELS}, events::AX_RH},
+
+            // Brackets for back and start
+            {{GLFW_KEY_LEFT_BRACKET, 0, 1}, events::BTN_BACK},
+            {{GLFW_KEY_RIGHT_BRACKET, 0, 1}, events::BTN_START},
+
+            // Enter for Xbox button
+            {{GLFW_KEY_ENTER, 0, 1}, events::BTN_XBOX},
+    };
+}

--- a/src/input/raw_maps/raw_map.cpp
+++ b/src/input/raw_maps/raw_map.cpp
@@ -1,0 +1,16 @@
+#include "raw_map.h"
+
+namespace input {
+bool operator<(const RawButton& l, const RawButton& r) {
+    if (l.is_button != r.is_button)
+        return l.is_button < r.is_button;
+    return l.input < r.input;
+}
+
+bool operator<(const RawKeyboard& l, const RawKeyboard& r) {
+    if (l.key != r.key)
+        return l.key < r.key;
+    return l.mods < r.mods;
+    // Level is not used in lookup
+}
+}

--- a/src/input/raw_maps/raw_map.h
+++ b/src/input/raw_maps/raw_map.h
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace input {
+// Comparators are for std::map usage.
+
+struct RawButton {
+    bool is_button;
+    int input; // Button or axis number
+};
+bool operator<(const RawButton& l, const RawButton& r);
+
+struct RawKeyboard {
+    int key;
+    int mods;
+    int level; // Defines the analog level for the keypress
+};
+bool operator<(const RawKeyboard& l, const RawKeyboard& r);
+}

--- a/src/input/raw_maps/xbox.h
+++ b/src/input/raw_maps/xbox.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <GL/glew.h>
+#include <GLFW/glfw3.h>
+
+#include "raw_map.h"
+#include "events.h"
+
+namespace input {
+    const std::map<RawButton, events::ConceptualButton> BTN_MAP_XBOX {
+            // TODO
+    };
+}

--- a/src/ui/build_ui.cpp
+++ b/src/ui/build_ui.cpp
@@ -77,5 +77,6 @@ BuildUI::~BuildUI() {
 void BuildUI::update_info_panel(int content_index) {
     title_label.set_text(constructs[content_index].name);
     description_label.set_text(constructs[content_index].description);
-    cost_label.set_text(std::to_string(constructs[content_index].cost) + "g");
+    std::string s = std::to_string(constructs[content_index].cost) + "g";
+    cost_label.set_text(s);
 }


### PR DESCRIPTION
Created an abstraction layer for our controls. The definition of conceptual
buttons are in `event.h`. The wiring for joypad input will come in a subsequent PR,
but this should be good to work with for now.