### PR TITLE
Process joystick events in ConceptualTranslator

### DIFF
--- a/src/aldente_client.cpp
+++ b/src/aldente_client.cpp
@@ -3,6 +3,7 @@
 #include "window.h"
 #include "input/conceptual_translator.h"
 #include "input/raw_maps/xbox.h"
+#include "input/raw_maps/matricom.h"
 #include "input/raw_maps/debug.h"
 #include "asset_loader.h"
 #include "physics.h"
@@ -55,7 +56,7 @@ void AldenteClient::start() {
     Window window(game_name, true, width, height);
 
     // Create raw input translator.
-    input::ConceptualTranslator translator(input::BTN_MAP_XBOX, input::KBD_MAP_DEBUG);
+    input::ConceptualTranslator translator(input::BTN_MAP_MATRICOM, input::KBD_MAP_DEBUG);
 
     // Setup subsystems after window creation.
     glSetup();

--- a/src/events.h
+++ b/src/events.h
@@ -28,6 +28,7 @@ namespace events {
         BTN_A, BTN_B, BTN_X, BTN_Y, // Face buttons
         BTN_BACK, BTN_XBOX, BTN_START, // Middle buttons
         BTN_LB, BTN_RB, // Bumpers
+        BTN_LS, BTN_RS, // Stick presses
 
         AX_LV, AX_LH, AX_RV, AX_RH, // Left and right sticks, vertical and horizontal axes
         AX_LT, AX_RT, // Left and right triggers

--- a/src/input/conceptual_translator.cpp
+++ b/src/input/conceptual_translator.cpp
@@ -5,6 +5,7 @@ namespace input {
             const std::map<RawButton, events::ConceptualButton> &joy_map_,
             const std::map<RawKeyboard, events::ConceptualButton> &key_map_
     ) : joy_map(joy_map_), key_map(key_map_) {
+        // Any window will trigger buttons.
         events::window_key_event.connect([&](const events::WindowKeyData &d) {
             // Ignore repeats
             if (d.action == GLFW_REPEAT) return;
@@ -24,6 +25,20 @@ namespace input {
 
             // Emit the event with controller ID 0
             events::ButtonData next_d = {0, button, state};
+            events::button_event(next_d);
+        });
+
+        events::joystick_event.connect([&](const events::JoystickData &d) {
+            const auto &found = joy_map.find({d.is_button, d.input});
+            // Bail if not in mapping
+            if (found == joy_map.end()) return;
+
+            // Cache the input
+            const events::ConceptualButton button = found->second;
+            cache[button] = d.state;
+
+            // Emit the event with the controller
+            events::ButtonData next_d = {d.id, button, d.state};
             events::button_event(next_d);
         });
     }

--- a/src/input/raw_maps/debug.h
+++ b/src/input/raw_maps/debug.h
@@ -26,6 +26,10 @@ namespace input {
             {{GLFW_KEY_I, 0, 1}, events::BTN_RB},
             {{GLFW_KEY_O, 0, events::INPUT_ANALOG_LEVELS}, events::AX_RT},
 
+            // N, M for stick presses
+            {{GLFW_KEY_N, 0, 1}, events::BTN_LS},
+            {{GLFW_KEY_M, 0, 1}, events::BTN_RS},
+
             // WASD for left stick
             {{GLFW_KEY_W, 0, -events::INPUT_ANALOG_LEVELS}, events::AX_LV},
             {{GLFW_KEY_A, 0, -events::INPUT_ANALOG_LEVELS}, events::AX_LH},

--- a/src/input/raw_maps/matricom.h
+++ b/src/input/raw_maps/matricom.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "raw_map.h"
+#include "events.h"
+
+namespace input {
+    const std::map<RawButton, events::ConceptualButton> BTN_MAP_MATRICOM {
+            // D-Pad
+            {{true, 13}, events::BTN_UP},
+            {{true, 16}, events::BTN_LEFT},
+            {{true, 15}, events::BTN_DOWN},
+            {{true, 14}, events::BTN_RIGHT},
+
+            // ABXY
+            {{true, 1}, events::BTN_A},
+            {{true, 2}, events::BTN_B},
+            {{true, 0}, events::BTN_X},
+            {{true, 3}, events::BTN_Y},
+
+            // Shoulders
+            {{true, 6}, events::AX_LT},
+            {{true, 4}, events::BTN_LB},
+            {{true, 5}, events::BTN_RB},
+            {{true, 7}, events::AX_RT},
+
+            // Stick presses
+            {{true, 10}, events::BTN_LS},
+            {{true, 11}, events::BTN_RS},
+
+            // Left stick
+            {{false, 0}, events::AX_LH},
+            {{false, 1}, events::AX_LV},
+
+            // Right stick
+            {{false, 2}, events::AX_RH},
+            {{false, 3}, events::AX_RV},
+
+            // Back, start
+            {{true, 8}, events::BTN_BACK},
+            {{true, 9}, events::BTN_START},
+
+            // Xbox button
+            {{true, 12}, events::BTN_XBOX},
+    };
+}

--- a/src/input/raw_maps/raw_map.cpp
+++ b/src/input/raw_maps/raw_map.cpp
@@ -1,16 +1,13 @@
 #include "raw_map.h"
+#include <tuple>
 
 namespace input {
 bool operator<(const RawButton& l, const RawButton& r) {
-    if (l.is_button != r.is_button)
-        return l.is_button < r.is_button;
-    return l.input < r.input;
+    return std::tie(l.is_button, l.input) < std::tie(r.is_button, r.input);
 }
 
 bool operator<(const RawKeyboard& l, const RawKeyboard& r) {
-    if (l.key != r.key)
-        return l.key < r.key;
-    return l.mods < r.mods;
+    return std::tie(l.mods, l.key) < std::tie(r.mods, r.key);
     // Level is not used in lookup
 }
 }

--- a/src/poll/input_poller.cpp
+++ b/src/poll/input_poller.cpp
@@ -24,24 +24,15 @@ void InputPoller::poll() {
     }
 
     static std::vector<int> p_axes;
-    static std::vector<int> frames;
-    static int sensitivity = 30;
     const float *axes = glfwGetJoystickAxes(GLFW_JOYSTICK_1, &count);
     p_axes.resize(static_cast<unsigned long>(count), 0);
-    frames.resize(static_cast<unsigned int>(count), sensitivity);
     if (axes) {
         for (int i = 0; i < count; ++i) {
             static float step = static_cast<float>(1.0 / events::INPUT_ANALOG_LEVELS);
             const int level = static_cast<int>(axes[i] / step);
             const bool same = p_axes[i] == level;
             p_axes[i] = level;
-            if (same && --(frames[i]) == 0) {
-                frames[i] = sensitivity;
-                events::JoystickData d = {1, false, i, level};
-                events::joystick_event(d);
-            }
             if (!same) {
-                frames[i] = sensitivity;
                 events::JoystickData d = {1, false, i, level};
                 events::joystick_event(d);
             }


### PR DESCRIPTION
Also:

- Add Matricom button mapping
- Add stick presses as conceptual buttons
- Fix `operator<` for RawButton/RawKeyboard with `std::tie`
- Remove Richard's InputPoller changes
  (if required, should be implemented as a layer on top of `stick_event`)

Next time:

- Add Xbox button mapping
- Make mapping configurable via config file (maybe)