### PR TITLE
Timer and server loop

### DIFF
--- a/src/aldente_server.cpp
+++ b/src/aldente_server.cpp
@@ -1,0 +1,25 @@
+#include "aldente_server.h"
+
+#include "timer.h"
+#include <chrono>
+#include <iostream>
+
+void AldenteServer::start() {
+    Timer timer(GAME_TICK);
+    Timer::provide(&timer);
+
+    Timer::get()->do_after(std::chrono::seconds(1), [](std::chrono::duration<double> d) {
+        std::cout << "print me once after one second" << std::endl;
+    });
+
+    const std::function<void()> cancel = Timer::get()->do_every(std::chrono::milliseconds(500),
+                                                               [&cancel](std::chrono::duration<double> d) {
+        static int count = 0;
+        std::cout << "print me every 0.5 seconds: (" << ++count << " / 5)" << std::endl;
+        if (count >= 5) cancel();
+    });
+
+    while (true) {
+        Timer::get()->wait();
+    }
+}

--- a/src/aldente_server.h
+++ b/src/aldente_server.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "aldente.h"
+
+class AldenteServer : public Aldente {
+public:
+    void start();
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include "catch.h"
 #include "aldente.h"
 #include "aldente_client.h"
+#include "aldente_server.h"
 
 
 int main(int argc, const char *argv[]) {
@@ -19,8 +20,7 @@ int main(int argc, const char *argv[]) {
         if (selection == "test") {
             exit(Catch::Session().run(argc, argv));
         } else if (selection == "server") {
-            std::cerr << "Server not implemented yet." << std::endl;
-            exit(EXIT_FAILURE);
+            aldente = new AldenteServer;
         } else {
             std::cerr << "Invalid argument." << std::endl;
             exit(EXIT_FAILURE);

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -1,0 +1,90 @@
+#include "timer.h"
+
+#include <assert.h>
+#include <thread>
+
+namespace chrono = std::chrono;
+using chrono::system_clock;
+
+Timer::Timer(Duration tick)
+        : tick(tick),
+          last_tick(system_clock::now()) {}
+
+Timer *Timer::instance = nullptr;
+
+void Timer::provide(Timer *timer) {
+    instance = timer;
+}
+
+Timer *Timer::get() {
+    assert(instance);
+    return instance;
+}
+
+void Timer::wait() {
+    // Handle cancels
+    for (int id : to_cancel) {
+        // IDs are shared among afters/everys, so just erase from both
+        afters.erase(id);
+        everys.erase(id);
+    }
+    to_cancel.clear();
+
+    // Handle callbacks
+    operate(afters, true);
+    operate(everys, false);
+
+    // Calculate how long to wait
+    Time now = system_clock::now();
+    Duration delta = now - last_tick;
+    Duration to_wait = tick - delta;
+
+    // Block until next tick
+    assert(to_wait >= chrono::milliseconds(0));
+    std::this_thread::sleep_for(to_wait);
+    last_tick = system_clock::now();
+}
+
+void Timer::operate(std::map<int, Operation> &ops, bool remove_when_executed) {
+    // Iterate and possibly modify map
+    for (auto &p : ops) {
+        int id = p.first;
+        Operation &op = p.second;
+
+        // Update remaining time
+        Time now = system_clock::now();
+        op.remaining -= now - op.last_check;
+        op.last_check = now;
+
+        // If all time elapsed, callback and remove or reset
+        if (op.remaining <= chrono::milliseconds(0)) {
+            op.callback(-op.remaining);
+
+            if (remove_when_executed) {
+                to_cancel.push_back(id);
+            } else {
+                op.remaining += op.when;
+            }
+        }
+    }
+}
+
+std::function<void()> Timer::do_after(const Duration time, const std::function<void(Duration)> callback) {
+    return add_op(afters, time, callback);
+}
+
+std::function<void()> Timer::do_every(const Duration time, const std::function<void(Duration)> callback) {
+    return add_op(everys, time, callback);
+}
+
+std::function<void()> Timer::add_op(std::map<int, Operation> &to, const Duration time,
+                                    const std::function<void(Duration)> callback) {
+    static int id = 0;
+    int cur_id = ++id;
+    to.emplace(cur_id, Operation{time, system_clock::now(), time, callback});
+
+    // Return a function which will add the corresponding ID to the cancel queue
+    return [this, cur_id]() {
+        to_cancel.push_back(cur_id);
+    };
+}

--- a/src/timer.h
+++ b/src/timer.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <map>
+#include <vector>
+#include <chrono>
+#include <functional>
+
+#define GAME_TICK std::chrono::milliseconds(30)
+
+// A single-threaded event loop style timer.
+class Timer {
+typedef std::chrono::time_point<std::chrono::system_clock> Time;
+typedef std::chrono::duration<double> Duration;
+
+public:
+    Timer(Duration tick);
+
+    // Setter/getter for static instance
+    static void provide(Timer *timer);
+    static Timer *get();
+
+    // Runs all timed out callbacks and causes the timer to block the thread until the next tick interval
+    void wait();
+
+    // Run callback once after the specified duration in seconds.
+    // The callback receives as a parameter the number of seconds after the requested callback time that the
+    // callback was actually executed.
+    // Returns a function that can be called to cancel the operation.
+    std::function<void()> do_after(const Duration time, const std::function<void(Duration)> callback);
+
+    // Run callback every specified duration in seconds.
+    // Duration will be adjusted to be as close to schedule as possible.
+    // The callback receives as a parameter the number of seconds after the requested callback time that the
+    // callback was actually executed.
+    // Returns a function that can be called to cancel the operation.
+    std::function<void()> do_every(const Duration time, const std::function<void(Duration)> callback);
+
+private:
+    static Timer *instance;
+
+    Duration tick;
+    Time last_tick;
+
+    struct Operation {
+        const Duration when; // When to fire
+        Time last_check; // Last time this Operation was checked
+        Duration remaining; // Mutable time remaining until operation execution
+        const std::function<void(Duration)> callback;
+    };
+
+    // Callback maps from ID -> function
+    std::map<int, Operation> afters;
+    std::map<int, Operation> everys;
+
+    // Queue for callback IDs to cancel
+    std::vector<int> to_cancel;
+
+    // Helper to register operations
+    std::function<void()> add_op(std::map<int, Operation> &to, const Duration time,
+                                 const std::function<void(Duration)> callback);
+
+    // Helper to handle operations
+    void operate(std::map<int, Operation> &ops, bool remove_when_executed);
+};


### PR DESCRIPTION
A very basic `Timer` class and the outline for the server loop.

Recommended usage:
- Instantiate one `Timer` and provide it as the singular timer instance across the code lifetime with `Timer::provide()`.
- Call `Timer::get()->wait()` once per top-level game loop iteration to force every iteration to be `GAME_TICK` long (30 ms). This is also responsible for invoking expired timeout callbacks.
- Run a one-time timed callback with `Timer::get()->do_after()`.
- Run a recurring timed callback with `Timer::get()->do_every()`.
- Cancel any timed callback by calling the return value of `Timer::get()->do_*()`.
- All time duration values should be of `std::chrono::duration`.

Implementation details:
- One map for `afters` and one map for `everys`.
- One queue for ID's to cancel at the start of every `wait()`.