### PR TITLE
Ghost trigger

### DIFF
--- a/src/events.h
+++ b/src/events.h
@@ -109,6 +109,8 @@ namespace events {
 
         //Object that has the rigidBody
         GameObject *object;
+        // whether this rigidbody is a ghost/trigger
+        bool trigger;
     };
     extern signal<void(RigidBodyData d)> add_rigidbody_event;
     extern signal<void(GameObject *obj)> remove_rigidbody_event;

--- a/src/events.h
+++ b/src/events.h
@@ -110,7 +110,7 @@ namespace events {
         //Object that has the rigidBody
         GameObject *object;
         // whether this rigidbody is a ghost/trigger
-        bool trigger;
+        bool is_ghost;
     };
     extern signal<void(RigidBodyData d)> add_rigidbody_event;
     extern signal<void(GameObject *obj)> remove_rigidbody_event;

--- a/src/game_objects/construct.cpp
+++ b/src/game_objects/construct.cpp
@@ -15,6 +15,7 @@ Crate::Crate(int x, int z) : Construct(x, z) {
         hit_box, //btshape
         glm::vec3(0,0,0), //inertia
         this, //the gameobject
+        true
     };
     events::add_rigidbody_event(rigid);
 }

--- a/src/game_objects/construct.cpp
+++ b/src/game_objects/construct.cpp
@@ -15,7 +15,7 @@ Crate::Crate(int x, int z) : Construct(x, z) {
         hit_box, //btshape
         glm::vec3(0,0,0), //inertia
         this, //the gameobject
-        true
+        true, // is a ghost object
     };
     events::add_rigidbody_event(rigid);
 }

--- a/src/game_objects/player.cpp
+++ b/src/game_objects/player.cpp
@@ -15,7 +15,7 @@ Player::Player() : GameObject() {
         1, //mass
         hit_capsule, //btshape
         glm::vec3(0,0,0), //inertia
-        this //the gameobject
+        this, //the gameobject
     };
     events::add_rigidbody_event(rigid);
 

--- a/src/game_objects/player.cpp
+++ b/src/game_objects/player.cpp
@@ -15,10 +15,10 @@ Player::Player() : GameObject() {
         1, //mass
         hit_capsule, //btshape
         glm::vec3(0,0,0), //inertia
-        this, //the gameobject
+        this //the gameobject
     };
     events::add_rigidbody_event(rigid);
-    
+
     // Lock y-axis
     rigidbody->setLinearFactor(btVector3(1, 0.0f, 1));
     //Lock angular rotation
@@ -27,6 +27,8 @@ Player::Player() : GameObject() {
     setup_listeners();
 
     transform.set_position(2.0f, 0.0f, 2.0f);
+
+    notify_on_collision = true;
 }
 
 void Player::setup_listeners() {

--- a/src/game_objects/tile.cpp
+++ b/src/game_objects/tile.cpp
@@ -60,6 +60,7 @@ WallTile::WallTile(int x, int z) : Tile::Tile() {
         hit_box, //btshape
         glm::vec3(0,0,0), //inertia
         this, //the gameobject
+        true
     };
     events::add_rigidbody_event(rigid);
 }

--- a/src/game_objects/tile.cpp
+++ b/src/game_objects/tile.cpp
@@ -59,8 +59,7 @@ WallTile::WallTile(int x, int z) : Tile::Tile() {
         0, //mass
         hit_box, //btshape
         glm::vec3(0,0,0), //inertia
-        this, //the gameobject
-        true
+        this //the gameobject
     };
     events::add_rigidbody_event(rigid);
 }

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -184,6 +184,10 @@ void Physics::add_rigid(events::RigidBodyData d) {
     rigidbody->setUserPointer(d.object);
     d.object->set_rigid(rigidbody);
 
+    // Set this rigidbody as a trigger.
+    if (d.trigger)
+        rigidbody->setCollisionFlags(btCollisionObject::CF_NO_CONTACT_RESPONSE);
+
     dynamicsWorld->addRigidBody(rigidbody);
 }
 

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -185,7 +185,7 @@ void Physics::add_rigid(events::RigidBodyData d) {
     d.object->set_rigid(rigidbody);
 
     // Set this rigidbody as a trigger.
-    if (d.trigger)
+    if (d.is_ghost)
         rigidbody->setCollisionFlags(btCollisionObject::CF_NO_CONTACT_RESPONSE);
 
     dynamicsWorld->addRigidBody(rigidbody);


### PR DESCRIPTION
Allow for objects to be phased through (ghosts), but still count for collision detection.

Just pass a true flag to the last field of the RigidBodyData.