### PR TITLE
Alpha and Ambience

### DIFF
--- a/shaders/anim_basic/frag.glsl
+++ b/shaders/anim_basic/frag.glsl
@@ -4,6 +4,8 @@ struct Material {
     vec3 specular;
     vec3 ambient;
     float shininess;
+    bool shadows_enabled;
+    float alpha;
 };
 
 struct DirLight {
@@ -55,7 +57,6 @@ uniform int num_spot_lights;
 uniform bool texture_enabled;
 uniform sampler2D texture_map;
 
-uniform bool shadows_enabled;
 uniform sampler2D shadow_map;
 
 vec3 calc_dir_light(DirLight light, Material mat, vec3 normal, vec3 view_dir, bool is_shadow_light);
@@ -94,7 +95,7 @@ void main()
         result += calc_spot_light(spot_lights[i], mat, normal, view_dir, false);
     }
 
-    color = vec4(result, 1.0f);
+    color = vec4(result, material.alpha);
 }
 
 vec3 calc_dir_light(DirLight light, Material mat,
@@ -168,7 +169,7 @@ vec3 calc_color(Material mat,
 
     // Shadows
     float shadow = 0;
-    if (shadows_enabled && is_shadow_light)
+    if (material.shadows_enabled && is_shadow_light)
         shadow = calc_shadows(frag_pos_light, light_dir);
     return (1.0 - shadow) * (diffuse + specular) + ambient;
 }

--- a/shaders/anim_basic/frag.glsl
+++ b/shaders/anim_basic/frag.glsl
@@ -2,7 +2,6 @@
 struct Material {
     vec3 diffuse;
     vec3 specular;
-    vec3 ambient;
     float shininess;
     bool shadows_enabled;
     float alpha;
@@ -76,7 +75,6 @@ void main()
     if (texture_enabled){
         vec3 tex_color = vec3(texture(texture_map, frag_tex_coord));
         mat.diffuse = tex_color * mat.diffuse;
-        mat.ambient = tex_color * mat.ambient;
     }
 
     // Do lighting
@@ -164,8 +162,8 @@ vec3 calc_color(Material mat,
         mat.specular *
         pow(max(dot(normal, normalize(light_dir + view_dir)), 0.0), mat.shininess);
 
-    // Ambient: c_a (ambient color) * k_a (coeff)
-    vec3 ambient = mat.ambient * ambient_coeff;
+    // Ambient: c_a (diffuse color) * k_a (coeff)
+    vec3 ambient = mat.diffuse * ambient_coeff;
 
     // Shadows
     float shadow = 0;

--- a/shaders/anim_unlit/frag.glsl
+++ b/shaders/anim_unlit/frag.glsl
@@ -1,6 +1,7 @@
 #version 330 core
 struct Material {
     vec3 diffuse;
+    float alpha;
 };
 
 in vec3 frag_pos;
@@ -26,5 +27,5 @@ void main()
         result = tex_color;
     }
 
-    color = vec4(result, 1.0f);
+    color = vec4(result, material.alpha);
 }

--- a/shaders/basic/frag.glsl
+++ b/shaders/basic/frag.glsl
@@ -4,6 +4,8 @@ struct Material {
     vec3 specular;
     vec3 ambient;
     float shininess;
+    bool shadows_enabled;
+    float alpha;
 };
 
 struct DirLight {
@@ -55,7 +57,6 @@ uniform int num_spot_lights;
 uniform bool texture_enabled;
 uniform sampler2D texture_map;
 
-uniform bool shadows_enabled;
 uniform sampler2D shadow_map;
 
 vec3 calc_dir_light(DirLight light, Material mat, vec3 normal, vec3 view_dir, bool is_shadow_light);
@@ -94,7 +95,7 @@ void main()
         result += calc_spot_light(spot_lights[i], mat, normal, view_dir, false);
     }
 
-    color = vec4(result, 1.0f);
+    color = vec4(result, material.alpha);
 }
 
 vec3 calc_dir_light(DirLight light, Material mat,
@@ -168,7 +169,7 @@ vec3 calc_color(Material mat,
 
     // Shadows
     float shadow = 0;
-    if (shadows_enabled && is_shadow_light)
+    if (material.shadows_enabled && is_shadow_light)
         shadow = calc_shadows(frag_pos_light, light_dir);
     return (1.0 - shadow) * (diffuse + specular) + ambient;
 }

--- a/shaders/basic/frag.glsl
+++ b/shaders/basic/frag.glsl
@@ -2,7 +2,6 @@
 struct Material {
     vec3 diffuse;
     vec3 specular;
-    vec3 ambient;
     float shininess;
     bool shadows_enabled;
     float alpha;
@@ -76,7 +75,6 @@ void main()
     if (texture_enabled){
         vec3 tex_color = vec3(texture(texture_map, frag_tex_coord));
         mat.diffuse = tex_color * mat.diffuse;
-        mat.ambient = tex_color * mat.ambient;
     }
 
     // Do lighting
@@ -164,8 +162,8 @@ vec3 calc_color(Material mat,
         mat.specular *
         pow(max(dot(normal, normalize(light_dir + view_dir)), 0.0), mat.shininess);
 
-    // Ambient: c_a (ambient color) * k_a (coeff)
-    vec3 ambient = mat.ambient * ambient_coeff;
+    // Ambient: c_a (diffuse color) * k_a (coeff)
+    vec3 ambient = mat.diffuse * ambient_coeff;
 
     // Shadows
     float shadow = 0;

--- a/shaders/unlit/frag.glsl
+++ b/shaders/unlit/frag.glsl
@@ -1,6 +1,7 @@
 #version 330 core
 struct Material {
     vec3 diffuse;
+    float alpha;
 };
 
 in vec3 frag_pos;
@@ -26,5 +27,5 @@ void main()
         result = tex_color;
     }
 
-    color = vec4(result, 1.0f);
+    color = vec4(result, material.alpha);
 }

--- a/src/asset_loader.cpp
+++ b/src/asset_loader.cpp
@@ -183,13 +183,10 @@ Mesh *AssetLoader::process_mesh(aiMesh *mesh, const aiScene *scene) {
     aiMaterial *assimpMat = scene->mMaterials[mesh->mMaterialIndex];
     aiColor3D diffuse(0, 0, 0);
     assimpMat->Get(AI_MATKEY_COLOR_DIFFUSE, diffuse);
-    aiColor3D ambient(0, 0, 0);
-    assimpMat->Get(AI_MATKEY_COLOR_AMBIENT, ambient);
     aiColor3D specular(0, 0, 0);
     assimpMat->Get(AI_MATKEY_COLOR_SPECULAR, specular);
     float shiny = 0.0f;
     assimpMat->Get(AI_MATKEY_SHININESS, shiny);
-    load_mat->ambient = Color(ambient.r, ambient.g, ambient.b);
     load_mat->diffuse = Color(diffuse.r, diffuse.g, diffuse.b);
     load_mat->specular = Color(specular.r, specular.g, specular.b);
     load_mat->shininess = shiny;

--- a/src/game_objects/game_object.cpp
+++ b/src/game_objects/game_object.cpp
@@ -72,6 +72,9 @@ void GameObject::set_alpha(float alpha) {
     model->set_alpha(alpha);
 }
 
+void GameObject::set_shadows(bool enable) {
+    model->set_shadows(enable);
+}
 // Sets position of both object's transform and rigid body
 // Use this intead of transform.set_position to make sure that rigid body
 // is located in the same place as the object

--- a/src/game_objects/game_object.cpp
+++ b/src/game_objects/game_object.cpp
@@ -63,12 +63,13 @@ void GameObject::connect_skel_to_model() {
     model->set_bones(&skel);
 }
 
-
 // Sets the material color for the entire game object's model
 void GameObject::set_color(Color color) {
-    for (Mesh* mesh : model->meshes) {
-        mesh->material->diffuse = color;
-    }
+    model->set_color(color);
+}
+
+void GameObject::set_alpha(float alpha) {
+    model->set_alpha(alpha);
 }
 
 // Sets position of both object's transform and rigid body

--- a/src/game_objects/game_object.h
+++ b/src/game_objects/game_object.h
@@ -48,6 +48,7 @@ public:
     void connect_skel_to_model();
 
     void set_color(Color color);
+    void set_alpha(float alpha);
 
     Model* get_model() { return model; };
     Skeleton get_skeleton() { return skel; };

--- a/src/game_objects/game_object.h
+++ b/src/game_objects/game_object.h
@@ -49,6 +49,7 @@ public:
 
     void set_color(Color color);
     void set_alpha(float alpha);
+    void set_shadows(bool enable);
 
     Model* get_model() { return model; };
     Skeleton get_skeleton() { return skel; };

--- a/src/game_objects/player.cpp
+++ b/src/game_objects/player.cpp
@@ -19,6 +19,9 @@ Player::Player() : GameObject() {
     };
     events::add_rigidbody_event(rigid);
 
+    // Notify on collision.
+    notify_on_collision = true;
+
     // Lock y-axis
     rigidbody->setLinearFactor(btVector3(1, 0.0f, 1));
     //Lock angular rotation
@@ -82,7 +85,6 @@ void Player::do_movement() {
             anim_player.play();
         }
     }
-
 }
 
 void Player::interact() {
@@ -111,5 +113,5 @@ void Player::start_walk() {
 }
 
 void Player::on_collision(GameObject *other) {
-    transform.set_scale(transform.get_scale() * 0.99f);
+    set_alpha(0.5f);
 }

--- a/src/model/material.h
+++ b/src/model/material.h
@@ -14,13 +14,15 @@ public:
     Material(Color diffuse = Color::WHITE,
             Color ambient = Color(0.5f, 0.5f, 0.5f),
             Color specular = Color::WHITE,
-            GLfloat shininess = 50.f, bool shadows = true)
+            GLfloat shininess = 50.f, bool shadows = true,
+            GLfloat alpha=1.f)
         : ambient(ambient), diffuse(diffuse), specular(specular),
-          shininess(shininess), shadows(shadows) {}
+          shininess(shininess), shadows(shadows), alpha(alpha) {}
 
     Color ambient;
     Color diffuse;
     Color specular;
     GLfloat shininess;
     bool shadows;
+    GLfloat alpha;
 };

--- a/src/model/material.h
+++ b/src/model/material.h
@@ -12,14 +12,12 @@
 class Material {
 public:
     Material(Color diffuse = Color::WHITE,
-            Color ambient = Color(0.5f, 0.5f, 0.5f),
             Color specular = Color::WHITE,
             GLfloat shininess = 50.f, bool shadows = true,
             GLfloat alpha=1.f)
-        : ambient(ambient), diffuse(diffuse), specular(specular),
+        : diffuse(diffuse), specular(specular),
           shininess(shininess), shadows(shadows), alpha(alpha) {}
 
-    Color ambient;
     Color diffuse;
     Color specular;
     GLfloat shininess;

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -28,7 +28,6 @@ void Model::draw(Shader *shader, SceneInfo &scene_info, glm::mat4 to_world) {
 void Model::set_color(Color color) {
     for (Mesh *mesh : meshes) {
         mesh->material->diffuse = color;
-        mesh->material->ambient = color;
     }
 }
 

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -24,3 +24,16 @@ void Model::draw(Shader *shader, SceneInfo &scene_info, glm::mat4 to_world) {
         }
     }
 }
+
+void Model::set_color(Color color) {
+    for (Mesh *mesh : meshes) {
+        mesh->material->diffuse = color;
+        mesh->material->ambient = color;
+    }
+}
+
+void Model::set_alpha(float alpha) {
+    for (Mesh *mesh : meshes) {
+        mesh->material->alpha = alpha;
+    }
+}

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -37,3 +37,9 @@ void Model::set_alpha(float alpha) {
         mesh->material->alpha = alpha;
     }
 }
+
+void Model::set_shadows(bool enable) {
+    for (Mesh *mesh : meshes) {
+        mesh->material->shadows = enable;
+    }
+}

--- a/src/model/model.h
+++ b/src/model/model.h
@@ -31,6 +31,8 @@ public:
 
     void set_alpha(float alpha);
 
+    void set_shadows(bool enable);
+
     void set_bones(Skeleton *skel) { bones = skel->bones_final; };
 
     void set_shader(Shader *shader) { model_shader = shader; }

--- a/src/model/model.h
+++ b/src/model/model.h
@@ -27,6 +27,10 @@ public:
 
     void add_mesh(Mesh *m);
 
+    void set_color(Color color);
+
+    void set_alpha(float alpha);
+
     void set_bones(Skeleton *skel) { bones = skel->bones_final; };
 
     void set_shader(Shader *shader) { model_shader = shader; }

--- a/src/scene/directional_light.h
+++ b/src/scene/directional_light.h
@@ -9,7 +9,7 @@ public:
     DirectionalLight(glm::vec3 default_direction,
                      Color color = Color::WHITE,
                      float intensity = 1.f,
-                     float ambient_coeff = 0.2f) // standard 20% ambience
+                     float ambient_coeff = 0.07f) // standard 7% ambience
             : Light(intensity, ambient_coeff, color),
               default_direction(default_direction) {}
 

--- a/src/scene/point_light.h
+++ b/src/scene/point_light.h
@@ -10,7 +10,7 @@ public:
                Color color = Color::WHITE,
                float intensity = 0.5f,
                float quadratic = 0.07f, // 7% inverse square falloff
-               float ambient_coeff = 0.2f) // standard 20% ambience
+               float ambient_coeff = 0.07f) // standard 7% ambience
             : Light(intensity, ambient_coeff, color),
               default_position(default_position),
               quadratic(quadratic) {}

--- a/src/scene/spot_light.h
+++ b/src/scene/spot_light.h
@@ -14,7 +14,7 @@ public:
               float taper = 20.f, // exponential degree to which light tapers at the edges
               float intensity = 1.f,
               float quadratic = 0.1f, // 10% inverse square falloff
-              float ambient_coeff = 0.2f) // standard 20% ambience
+              float ambient_coeff = 0.07f) // standard 7% ambience
             : Light(intensity, ambient_coeff, color),
               default_position(default_position),
               default_direction(default_direction),

--- a/src/shaders/basic_shader.cpp
+++ b/src/shaders/basic_shader.cpp
@@ -28,7 +28,6 @@ void BasicShader::draw(Mesh *mesh, SceneInfo &scene_info, glm::mat4 to_world) {
     // Send material.
     set_uni("material.diffuse", mesh->material->diffuse.to_vec());
     set_uni("material.specular", mesh->material->specular.to_vec());
-    set_uni("material.ambient", mesh->material->ambient.to_vec());
     set_uni("material.shininess", mesh->material->shininess);
     set_uni("material.shadows_enabled", mesh->material->shadows);
     set_uni("material.alpha", mesh->material->alpha);

--- a/src/shaders/basic_shader.cpp
+++ b/src/shaders/basic_shader.cpp
@@ -30,7 +30,8 @@ void BasicShader::draw(Mesh *mesh, SceneInfo &scene_info, glm::mat4 to_world) {
     set_uni("material.specular", mesh->material->specular.to_vec());
     set_uni("material.ambient", mesh->material->ambient.to_vec());
     set_uni("material.shininess", mesh->material->shininess);
-    set_uni("shadows_enabled", mesh->material->shadows);
+    set_uni("material.shadows_enabled", mesh->material->shadows);
+    set_uni("material.alpha", mesh->material->alpha);
 
     // Send texture uniforms.
     set_uni("texture_enabled", mesh->geometry->has_texture);


### PR DESCRIPTION
- Added alpha values to Material class, to support transparent stuff
- Added convenience functions to alter alpha, color, and shadows at GameObject and Model levels.
- Removed ambient component from all materials, in favour of using diffuse * ambient_coefficient