### PR TITLE
Catch-up timer

### DIFF
--- a/src/aldente_client.cpp
+++ b/src/aldente_client.cpp
@@ -13,6 +13,7 @@
 #include "poll/input_poller.h"
 #include "util/config.h"
 #include "events.h"
+#include "timer.h"
 #include "ui/build_ui.h"
 #include "render.h"
 #include "game/game_state.h"
@@ -101,6 +102,10 @@ void AldenteClient::start() {
 
     std::cerr << "Starting client..." << std::endl;
 
+    // Used for callbacks
+    Timer timer(GAME_TICK);
+    Timer::provide(&timer);
+
     while (!window.should_close()) {
         // Do polling
         for (auto &poller : pollers) {
@@ -108,6 +113,7 @@ void AldenteClient::start() {
         }
 
         network.update();
+        Timer::get()->catch_up();
         GameState::client_update();
 
         render.update();

--- a/src/aldente_server.cpp
+++ b/src/aldente_server.cpp
@@ -17,27 +17,17 @@ void AldenteServer::start() {
     ServerNetworkManager network;
     network.connect();
 
+    std::cerr << "Starting server..." << std::endl;
+
     Timer timer(GAME_TICK);
     Timer::provide(&timer);
 
-    Timer::get()->do_after(std::chrono::seconds(1), [](std::chrono::duration<double> d) {
-        std::cout << "print me once after one second" << std::endl;
-    });
-
-    const std::function<void()> cancel = Timer::get()->do_every(
-            std::chrono::milliseconds(500),
-            [&cancel](std::chrono::duration<double> d) {
-                static int count = 0;
-                std::cout << "print me every 0.5 seconds: (" << ++count << " / 5)" << std::endl;
-                if (count >= 5) cancel();
-            });
-
-    std::cerr << "Starting server..." << std::endl;
-
     while (true) {
         network.update();
-        GameState::update();
-        Timer::get()->wait();
+
+        Timer::get()->catch_up([&]{
+            GameState::update();
+        });
     }
 
     network.disconnect();

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -7,8 +7,9 @@ namespace chrono = std::chrono;
 using chrono::system_clock;
 
 Timer::Timer(Duration tick)
-        : tick(tick),
-          last_tick(system_clock::now()) {}
+        : tick(tick)
+        , last_tick(system_clock::now())
+        , lag(0) {}
 
 Timer *Timer::instance = nullptr;
 
@@ -25,7 +26,22 @@ std::chrono::duration<double> Timer::so_far() {
     return system_clock::now() - last_tick;
 }
 
-void Timer::wait() {
+void Timer::catch_up(const std::function<void()> &update) {
+    // Calculate how long to wait
+    Time now = system_clock::now();
+    Duration elapsed = now - last_tick;
+    last_tick = now;
+    lag += elapsed;
+
+    // Update as many times as we need to catch up
+    while (lag >= tick) {
+        handle_operations(tick);
+        update();
+        lag -= tick;
+    }
+}
+
+void Timer::handle_operations(const Duration &elapsed) {
     // Handle cancels
     for (int id : to_cancel) {
         // IDs are shared among afters/everys, so just erase from both
@@ -35,30 +51,18 @@ void Timer::wait() {
     to_cancel.clear();
 
     // Handle callbacks
-    operate(afters, true);
-    operate(everys, false);
-
-    // Calculate how long to wait
-    Time now = system_clock::now();
-    Duration delta = now - last_tick;
-    Duration to_wait = tick - delta;
-
-    // Block until next tick
-    // assert(to_wait >= chrono::milliseconds(0));
-    std::this_thread::sleep_for(to_wait);
-    last_tick = system_clock::now();
+    operate(elapsed, afters, true);
+    operate(elapsed, everys, false);
 }
 
-void Timer::operate(std::map<int, Operation> &ops, bool remove_when_executed) {
+void Timer::operate(const Duration &elapsed, std::map<int, Operation> &ops, bool remove_when_executed) {
     // Iterate and possibly modify map
     for (auto &p : ops) {
         int id = p.first;
         Operation &op = p.second;
 
         // Update remaining time
-        Time now = system_clock::now();
-        op.remaining -= now - op.last_check;
-        op.last_check = now;
+        op.remaining -= elapsed;
 
         // If all time elapsed, callback and remove or reset
         if (op.remaining <= chrono::milliseconds(0)) {
@@ -73,19 +77,19 @@ void Timer::operate(std::map<int, Operation> &ops, bool remove_when_executed) {
     }
 }
 
-std::function<void()> Timer::do_after(const Duration time, const std::function<void(Duration)> callback) {
+std::function<void()> Timer::do_after(const Duration time, const std::function<void(Duration)> &callback) {
     return add_op(afters, time, callback);
 }
 
-std::function<void()> Timer::do_every(const Duration time, const std::function<void(Duration)> callback) {
+std::function<void()> Timer::do_every(const Duration time, const std::function<void(Duration)> &callback) {
     return add_op(everys, time, callback);
 }
 
 std::function<void()> Timer::add_op(std::map<int, Operation> &to, const Duration time,
-                                    const std::function<void(Duration)> callback) {
+                                    const std::function<void(Duration)> &callback) {
     static int id = 0;
     int cur_id = ++id;
-    to.emplace(cur_id, Operation{time, system_clock::now(), time, callback});
+    to.emplace(cur_id, Operation{time, time, callback});
 
     // Return a function which will add the corresponding ID to the cancel queue
     return [this, cur_id]() {


### PR DESCRIPTION
Implement catch-up behavior into server game loop using timer. That way, we don't have to worry about network stuff causing our updates to fall behind.

Also provide a timer to client for timed callbacks. This makes sense now that timer does not actually block.