### PR TITLE
Added debug line drawer for Bullet's colliders

### DIFF
--- a/src/aldente_client.cpp
+++ b/src/aldente_client.cpp
@@ -20,6 +20,7 @@
 #include "game/construct_types.h"
 #include "net/network_manager.h"
 #include "shaders/shader_manager.h"
+#include "bt_debug.h"
 
 AldenteClient::~AldenteClient() {
     GeometryGenerator::destroy();
@@ -82,6 +83,9 @@ void AldenteClient::start() {
 
     Render render(window, GameState::scene_manager);
 
+    btDebug bt_debug(&physics);
+    bt_debug.set_enable(true); // Set to false to disable debug lines for bullet
+
     // TODO : BuildUI initialiaziation should be done in BuildPhase setup()
     std::vector<ConstructData> constructs;
     for (int i = 0; i < 12; i++) {
@@ -117,6 +121,7 @@ void AldenteClient::start() {
         GameState::client_update();
 
         render.update();
+        bt_debug.draw(scene_manager.get_current_scene()->info);
         ui.draw();
         window.swap_buffers();
     }

--- a/src/aldente_client.cpp
+++ b/src/aldente_client.cpp
@@ -85,7 +85,6 @@ void AldenteClient::start() {
 
     // Debug Drawer for Bullet
     btDebug bt_debug(&GameState::physics);
-    bt_debug.set_enable(true); // Set to false to disable debug lines for bullet
 
     // TODO : BuildUI initialiaziation should be done in BuildPhase setup()
     std::vector<ConstructData> constructs;

--- a/src/aldente_client.cpp
+++ b/src/aldente_client.cpp
@@ -83,6 +83,7 @@ void AldenteClient::start() {
 
     Render render(window, GameState::scene_manager);
 
+    // Debug Drawer for Bullet
     btDebug bt_debug(&physics);
     bt_debug.set_enable(true); // Set to false to disable debug lines for bullet
 

--- a/src/aldente_client.cpp
+++ b/src/aldente_client.cpp
@@ -84,7 +84,7 @@ void AldenteClient::start() {
     Render render(window, GameState::scene_manager);
 
     // Debug Drawer for Bullet
-    btDebug bt_debug(&physics);
+    btDebug bt_debug(&GameState::physics);
     bt_debug.set_enable(true); // Set to false to disable debug lines for bullet
 
     // TODO : BuildUI initialiaziation should be done in BuildPhase setup()
@@ -122,7 +122,7 @@ void AldenteClient::start() {
         GameState::client_update();
 
         render.update();
-        bt_debug.draw(scene_manager.get_current_scene()->info);
+        bt_debug.draw(GameState::scene_manager.get_current_scene()->info);
         ui.draw();
         window.swap_buffers();
     }

--- a/src/bt_debug.cpp
+++ b/src/bt_debug.cpp
@@ -31,10 +31,15 @@ void btDebug::draw(SceneInfo &scene_info) {
     if (!enabled)
         return;
 
-    if (physics->dynamicsWorld)
-        physics->dynamicsWorld->setDebugDrawer(this);
+    if (physics->dynamicsWorld == NULL)
+        return;
+    
+    physics->dynamicsWorld->setDebugDrawer(this);
 
+    // Clears past buffers
     clear();
+
+    // Calls "drawLine" for all box colliders registered in the world
     physics->dynamicsWorld->debugDrawWorld();
 
     for (int i = 0; i < geo->vertices.size(); i++)
@@ -42,6 +47,7 @@ void btDebug::draw(SceneInfo &scene_info) {
 
     geo->populate_buffers();
 
+    // Draws all lines
     ShaderManager::unlit.use();
     ShaderManager::unlit.draw(lines, scene_info, glm::mat4(1.0f));
 }

--- a/src/bt_debug.cpp
+++ b/src/bt_debug.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include "shaders/shader_manager.h"
 #include "scene_manager.h"
+#include "events.h"
 
 btDebug::btDebug(Physics *physics) : physics(physics) {
     setDebugMode(btIDebugDraw::DBG_DrawWireframe);
@@ -15,6 +16,11 @@ btDebug::btDebug(Physics *physics) : physics(physics) {
     mat->shadows = false;
     lines->material = mat;
     lines->geometry = geo;
+
+    // Connect to debug toggle event.
+    events::debug::toggle_bt_debug_drawer_event.connect([&](void) {
+        enabled = !enabled;
+    });
 }
 
 void btDebug::set_enable(bool b) {

--- a/src/bt_debug.cpp
+++ b/src/bt_debug.cpp
@@ -1,0 +1,63 @@
+#include "bt_debug.h"
+#include "GL/glew.h"
+#include <iostream>
+#include "shaders/shader_manager.h"
+#include "scene_manager.h"
+
+btDebug::btDebug(Physics *physics) : physics(physics) {
+    setDebugMode(btIDebugDraw::DBG_DrawWireframe);
+
+    lines = new Mesh();
+    geo = new Geometry();
+    mat = new Material(Color::RED);
+
+    geo->draw_type = GL_LINES;
+    mat->shadows = false;
+    lines->material = mat;
+    lines->geometry = geo;
+}
+
+void btDebug::set_enable(bool b) {
+    enabled = b;
+}
+
+void btDebug::clear() {
+    geo->vertices.clear();
+    geo->normals.clear();
+    geo->indices.clear();
+}
+
+void btDebug::draw(SceneInfo &scene_info) {
+    if (!enabled)
+        return;
+
+    if (physics->dynamicsWorld)
+        physics->dynamicsWorld->setDebugDrawer(this);
+
+    clear();
+    physics->dynamicsWorld->debugDrawWorld();
+
+    for (int i = 0; i < geo->vertices.size(); i++)
+        geo->indices.push_back(i);
+
+    geo->populate_buffers();
+
+    ShaderManager::unlit.use();
+    ShaderManager::unlit.draw(lines, scene_info, glm::mat4(1.0f));
+}
+
+void btDebug::drawLine(const btVector3& from, const btVector3& to, const btVector3& color) {
+
+    geo->vertices.push_back({ from.getX(), from.getY(), from.getZ() });
+    geo->vertices.push_back({ to.getX(), to.getY(), to.getZ() });
+    geo->normals.push_back({ 1, 1, 1 });
+    geo->normals.push_back({ 1, 1, 1 });
+}
+
+void btDebug::setDebugMode(int mode) { 
+    debug_mode = (DebugDrawModes)mode; 
+}
+
+int btDebug::getDebugMode() const {
+    return debug_mode;
+}

--- a/src/bt_debug.h
+++ b/src/bt_debug.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "LinearMath/btIDebugDraw.h"
+#include "scene/scene_info.h"
+#include "model/mesh.h"
+#include "physics.h"
+
+/*
+    For drawing debug lines for bullet box colliders.
+*/
+class btDebug : public btIDebugDraw {
+public:
+
+    btDebug(Physics *physics);
+
+    void clear();
+    void draw(SceneInfo &scene_info);
+    void set_enable(bool b);
+    
+    void drawLine(const btVector3& from, const btVector3& to, const btVector3& color) override;
+    void drawContactPoint(const btVector3& PointOnB, const btVector3& normalOnB, btScalar distance, int lifeTime, const btVector3& color) override {};
+    void reportErrorWarning(const char* warningString) override {};
+    void draw3dText(const btVector3& location, const char* textString) override {};
+    void setDebugMode(int debugMode) override;
+    int getDebugMode() const override;
+
+private:
+    bool enabled;
+
+    int debug_mode;
+
+    Physics *physics;
+
+    Material *mat;
+    Geometry *geo;
+    Mesh *lines;
+};

--- a/src/bt_debug.h
+++ b/src/bt_debug.h
@@ -13,10 +13,11 @@ public:
 
     btDebug(Physics *physics);
 
-    void clear();
+    void clear(); // Clears buffers
     void draw(SceneInfo &scene_info);
     void set_enable(bool b);
     
+    /* Virtual functions from Bullet's Interface*/
     void drawLine(const btVector3& from, const btVector3& to, const btVector3& color) override;
     void drawContactPoint(const btVector3& PointOnB, const btVector3& normalOnB, btScalar distance, int lifeTime, const btVector3& color) override {};
     void reportErrorWarning(const char* warningString) override {};

--- a/src/bt_debug.h
+++ b/src/bt_debug.h
@@ -16,7 +16,7 @@ public:
     void clear(); // Clears buffers
     void draw(SceneInfo &scene_info);
     void set_enable(bool b);
-    
+
     /* Virtual functions from Bullet's Interface*/
     void drawLine(const btVector3& from, const btVector3& to, const btVector3& color) override;
     void drawContactPoint(const btVector3& PointOnB, const btVector3& normalOnB, btScalar distance, int lifeTime, const btVector3& color) override {};
@@ -26,7 +26,7 @@ public:
     int getDebugMode() const override;
 
 private:
-    bool enabled;
+    bool enabled = false;
 
     int debug_mode;
 

--- a/src/debug_input.cpp
+++ b/src/debug_input.cpp
@@ -45,6 +45,9 @@ DebugInput::DebugInput(Window &window, SceneManager &scene_manager, Physics &p) 
                 case GLFW_KEY_V:
                     events::debug::toggle_debug_input_event();
                     break;
+                case GLFW_KEY_B:
+                    events::debug::toggle_bt_debug_drawer_event();
+                    break;
                 case GLFW_KEY_0:
                     // FIXME(metakirby5)
                     break;

--- a/src/debug_input.cpp
+++ b/src/debug_input.cpp
@@ -79,6 +79,11 @@ DebugInput::DebugInput(Window &window, SceneManager &scene_manager, Physics &p) 
 
         last_cursor_pos = current_cursor_pos;
     });
+
+    events::debug::toggle_debug_input_event.connect([&]() {
+        debug_input_on = !debug_input_on;
+        scene_manager.get_camera()->disable_movement = debug_input_on;
+    });
 }
 
 // TODO: change this to a "FrameEdge" event callback

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -17,6 +17,7 @@ namespace events {
         signal<void()> toggle_light_rotation_event;
         signal<void()> toggle_debug_input_event;
         signal<void(Phase*)> client_set_phase_event;
+        signal<void()> toggle_bt_debug_drawer_event;
     }
 
     signal<void(int)> ui_grid_selection_event;

--- a/src/events.h
+++ b/src/events.h
@@ -102,6 +102,7 @@ namespace events {
         extern signal<void()> toggle_light_rotation_event;
         extern signal<void()> toggle_debug_input_event;
         extern signal<void(Phase*)> client_set_phase_event;
+        extern signal<void()> toggle_bt_debug_drawer_event;
     }
 
     // The user has made a selection on the UI grid.

--- a/src/game_objects/player.cpp
+++ b/src/game_objects/player.cpp
@@ -81,7 +81,7 @@ void Player::update_state(float x, float z, float wx, float wz, bool camera) {
             anim_player.play();
     }
 
-    transform.set_position(x, 0.0f, z);
+    set_position({ x, 0.0f, z });
     transform.look_at(glm::vec3(wx, 0, wz));
 
     // Fires the player's position whenever player moves so camera can follow.


### PR DESCRIPTION
Makes it easy to debug collisions within the game. Currently the debug drawer is on by default, but you can turn it off by setting `bt_debug.set_enable(false);` on line 88 in aldente_client.cpp.