### PR TITLE
Don't teardown and setup if no phase change

### DIFF
--- a/src/game/game_state.cpp
+++ b/src/game/game_state.cpp
@@ -62,6 +62,9 @@ void GameState::client_update() {
 }
 
 void GameState::set_phase(Phase* phase) {
+    // If no change to phase, don't teardown and setup.
+    if (phase == curr_phase) return;
+
     if (is_server) {
         if (curr_phase)
             curr_phase->teardown();


### PR DESCRIPTION
Fixes potential race conditions if e.g. you spam `1` or `2`, which repeatedly calls teardown/setup of phases.

This fixes (but does not entirely resolve) a bug where mashing `2` could potentially cause you to remove a Goal object before updating its state, since DungeonPhase's teardown removes an existing goal while setup adds one.

### Notes
* Phase changes won't be controlled by the client for the actual game