### PR TITLE
Model filter

### DIFF
--- a/src/animation/animation_player.cpp
+++ b/src/animation/animation_player.cpp
@@ -41,8 +41,13 @@ void AnimationPlayer::update() {
     last_time = glfwGetTime();
 }
 
-void AnimationPlayer::set_anim(Skeleton *skel, std::string anim_name) {
+void AnimationPlayer::set_skeleton(Skeleton *skel) {
     this->skel = skel;
+}
+
+void AnimationPlayer::set_anim(std::string anim_name) {
+    if (!skel) return; // cannot set animation without a skeleton
+
     animation = skel->animations[anim_name];
 
     if (animation == NULL) {

--- a/src/animation/animation_player.h
+++ b/src/animation/animation_player.h
@@ -11,7 +11,8 @@ class AnimationPlayer {
 public:
     AnimationPlayer();
 
-    void set_anim(Skeleton *skel, std::string anim_name);
+    void set_skeleton(Skeleton *skel);
+    void set_anim(std::string anim_name);
 
     void update(); // Updates bone matrices for model based on animation playing
     void play(); // Tells the animation player to start playing

--- a/src/game_objects/construct.cpp
+++ b/src/game_objects/construct.cpp
@@ -35,7 +35,7 @@ void Chest::update_this() {
 
 // Activated when a player presses A on it
 void Chest::interact_trigger() {
-    anim_player.set_anim(&skel, "open");
+    anim_player.set_anim("open");
     anim_player.play();
 }
 
@@ -70,7 +70,7 @@ void Goal::setup_model() {
     attach_model(AssetLoader::get_model("warp"));
     model->set_shader(&ShaderManager::anim_unlit);
     anim_player.set_speed(1.0f);
-    anim_player.set_anim(&skel, "spin");
+    anim_player.set_anim("spin");
     anim_player.set_loop(false);
 }
 

--- a/src/game_objects/game_object.cpp
+++ b/src/game_objects/game_object.cpp
@@ -90,6 +90,18 @@ void GameObject::connect_model_filter(){
     model->set_model_filter(model_filter);
 }
 
+void GameObject::set_filter_color(Color color) {
+    model_filter.material.diffuse = color;
+}
+
+void GameObject::set_filter_alpha(float alpha) {
+    model_filter.material.alpha = alpha;
+}
+
+void GameObject::set_filter_shadows(bool enable) {
+    model_filter.material.shadows = enable;
+}
+
 // Sets the material color for the entire game object's model
 void GameObject::set_color(Color color) {
     model->set_color(color);

--- a/src/game_objects/game_object.cpp
+++ b/src/game_objects/game_object.cpp
@@ -92,14 +92,17 @@ void GameObject::connect_model_filter(){
 
 void GameObject::set_filter_color(Color color) {
     model_filter.material.diffuse = color;
+    model_filter.override_diffuse = true;
 }
 
 void GameObject::set_filter_alpha(float alpha) {
     model_filter.material.alpha = alpha;
+    model_filter.override_alpha = true;
 }
 
 void GameObject::set_filter_shadows(bool enable) {
     model_filter.material.shadows = enable;
+    model_filter.override_shadows = true;
 }
 
 // Sets the material color for the entire game object's model

--- a/src/game_objects/game_object.cpp
+++ b/src/game_objects/game_object.cpp
@@ -44,7 +44,7 @@ void GameObject::remove_all() {
 // Renders model and children's models in scene
 void GameObject::draw(Shader *shader, SceneInfo &scene_info) {
     if (model) {
-        connect_skel_to_model();
+        connect_model_filter();
         model->draw(shader, scene_info, transform.get_world_mat());
     }
 
@@ -56,7 +56,7 @@ void GameObject::draw(Shader *shader, SceneInfo &scene_info) {
 void GameObject::draw_instanced(Shader *shader, SceneInfo &scene_info,
                       std::vector<glm::mat4> instance_matrix) {
     if (model) {
-        connect_skel_to_model();
+        connect_model_filter();
         model->draw_instanced(shader, scene_info, instance_matrix);
     }
 }
@@ -76,12 +76,17 @@ void GameObject::update_state(float x, float z, float wx, float wz) {
     transform.look_at(direction);
 }
 
-// Attaches bones from skeleton to model
+void GameObject::attach_model(Model *m) {
+    model = m;
+    model_filter.skeleton = m->initial_skeleton;
+}
+
+// Attaches bones from skeleton to model, as well as an overriding material for the model.
 // Allows for different game objects using the same model
 // to be animated independently. This needs to happen before each
 // one's draw call (i.e. cannot just be done in update)
-void GameObject::connect_skel_to_model() {
-    model->set_bones(&skel);
+void GameObject::connect_model_filter(){
+    model->set_model_filter(model_filter);
 }
 
 // Sets the material color for the entire game object's model
@@ -96,11 +101,11 @@ void GameObject::set_alpha(float alpha) {
 void GameObject::set_shadows(bool enable) {
     model->set_shadows(enable);
 }
+
 // Sets position of both object's transform and rigid body
 // Use this intead of transform.set_position to make sure that rigid body
 // is located in the same place as the object
 void GameObject::set_position(glm::vec3 pos) {
-
     // Set for Transform
     transform.set_position(pos);
 

--- a/src/game_objects/game_object.cpp
+++ b/src/game_objects/game_object.cpp
@@ -79,6 +79,7 @@ void GameObject::update_state(float x, float z, float wx, float wz) {
 void GameObject::attach_model(Model *m) {
     model = m;
     model_filter.skeleton = m->initial_skeleton;
+    anim_player.set_skeleton(&model_filter.skeleton);
 }
 
 // Attaches bones from skeleton to model, as well as an overriding material for the model.

--- a/src/game_objects/game_object.h
+++ b/src/game_objects/game_object.h
@@ -59,6 +59,9 @@ public:
     virtual void setup_instanced_model(int num_instances,
                                        std::vector<glm::mat4> instance_matrix = std::vector<glm::mat4>()) {};
 
+    void set_filter_color(Color color);
+    void set_filter_alpha(float alpha);
+    void set_filter_shadows(bool enable);
     void set_color(Color color);
     void set_alpha(float alpha);
     void set_shadows(bool enable);

--- a/src/game_objects/game_object.h
+++ b/src/game_objects/game_object.h
@@ -6,6 +6,7 @@
 #include "animation/animation_player.h"
 #include "btBulletDynamicsCommon.h"
 #include "util/color.h"
+#include "model/model_filter.h"
 
 #include <unordered_map>
 #include <string>
@@ -18,9 +19,11 @@
 class GameObject {
 private:
     static int id_counter;
+
+    void connect_model_filter();
 protected:
     Model *model;
-    Skeleton skel;
+    ModelFilter model_filter;
     AnimationPlayer anim_player;
     btRigidBody *rigidbody;
     int id;
@@ -56,15 +59,12 @@ public:
     virtual void setup_instanced_model(int num_instances,
                                        std::vector<glm::mat4> instance_matrix = std::vector<glm::mat4>()) {};
 
-    void connect_skel_to_model();
-
     void set_color(Color color);
     void set_alpha(float alpha);
     void set_shadows(bool enable);
 
     Model* get_model() { return model; };
-    Skeleton get_skeleton() { return skel; };
-    void attach_model(Model *m) { model = m; skel = m->initial_skeleton; };
+    void attach_model(Model *m);
 
     btRigidBody *get_rigid() { return rigidbody; };
     void set_rigid(btRigidBody *to_add) { rigidbody = to_add; };

--- a/src/game_objects/grid.cpp
+++ b/src/game_objects/grid.cpp
@@ -172,11 +172,7 @@ void Grid::move_selection(Direction d) {
 
 // Updates Selected Tile Color
 void Grid::update_selection() {
-    if (grid[hover_row][hover_col] != hover) {
-        hover->set_color(default_color);
-        hover = grid[hover_row][hover_col];
-        hover->set_color(select_color);
-    }
+    // TODO: modify the construct's filter to have transparent material.
 }
 
 void Grid::load_map(const char *map_loc) {

--- a/src/game_objects/player.cpp
+++ b/src/game_objects/player.cpp
@@ -111,7 +111,7 @@ void Player::stop_walk() {
 
 void Player::start_walk() {
     anim_player.set_speed(3.0f);
-    anim_player.set_anim(&skel, "walk");
+    anim_player.set_anim("walk");
     anim_player.set_loop(true);
     anim_player.play();
 }

--- a/src/game_objects/test_chest.cpp
+++ b/src/game_objects/test_chest.cpp
@@ -6,6 +6,6 @@ void TestChest::update_this() {
 }
 
 void TestChest::open_chest() {
-    anim_player.set_anim(&skel, "open");
+    anim_player.set_anim("open");
     anim_player.play();
 }

--- a/src/game_objects/test_coin.cpp
+++ b/src/game_objects/test_coin.cpp
@@ -10,7 +10,7 @@ void TestCoin::update_this() {
 }
 
 void TestCoin::spin_coin() {
-    anim_player.set_anim(&skel, "spin");
+    anim_player.set_anim("spin");
     anim_player.set_loop(true);
     anim_player.play();
 }

--- a/src/model/mesh.h
+++ b/src/model/mesh.h
@@ -7,6 +7,8 @@
 
 #include "geometry.h"
 #include "material.h"
+#include "model_filter.h"
+
 class Mesh {
 public:
     Mesh(Geometry *geo = NULL,
@@ -17,6 +19,7 @@ public:
 
     Geometry *geometry;
     Material *material;
+    ModelFilter model_filter;
     glm::mat4 local_transform;
 
     // map<string, Anim*> animations();

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -5,11 +5,12 @@ void Model::add_mesh(Mesh *m) {
 }
 
 void Model::draw(Shader *shader, SceneInfo &scene_info, glm::mat4 to_world) {
+    // Use model's attached shader if a NULL shader is passed in.
+    // Otherwise use passed in shader.
+    Shader *shader_to_use = shader == nullptr ? model_shader : shader;
+    shader_to_use->use();
+
     for (Mesh *mesh : meshes) {
-        // Use model's attached shader if a NULL shader is passed in.
-        // Otherwise use passed in shader.
-        Shader *shader_to_use = shader == nullptr ? model_shader : shader;
-        shader_to_use->use();
         shader_to_use->draw(mesh, scene_info, to_world);
     }
 }
@@ -17,10 +18,11 @@ void Model::draw(Shader *shader, SceneInfo &scene_info, glm::mat4 to_world) {
 // Draw multiple instances of this model according to the number of (transformation) mat4s in instance_matrix
 void Model::draw_instanced(Shader *shader, SceneInfo &scene_info,
                     std::vector<glm::mat4> &instance_matrix) {
+    // Use model's attached shader if a NULL shader is passed in.
+    Shader *shader_to_use = shader == nullptr ? model_shader : shader;
+    shader_to_use->use();
+
     for (Mesh *mesh : meshes) {
-        // Use model's attached shader if a NULL shader is passed in.
-        Shader *shader_to_use = shader == nullptr ? model_shader : shader;
-        shader_to_use->use();
         mesh->geometry->bind_instance_matrix(instance_matrix); // bind buffers on geometry
         // Pass identity to_world matrix because using instance_matrix for every instance
         shader_to_use->draw(mesh, scene_info, glm::mat4(1.f));

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -7,21 +7,10 @@ void Model::add_mesh(Mesh *m) {
 void Model::draw(Shader *shader, SceneInfo &scene_info, glm::mat4 to_world) {
     for (Mesh *mesh : meshes) {
         // Use model's attached shader if a NULL shader is passed in.
-        if (shader != nullptr) {
-            shader->use();
-            shader->draw(mesh, scene_info, to_world);
-        } else {
-            model_shader->use();
-
-            // Passes bones to shader manually to show that this model is animated
-            for (int i = 0; i < bones.size(); i++) {
-                char uni_name[128];
-                snprintf(uni_name, sizeof(uni_name), "bones[%d]", i);
-                model_shader->set_uni(uni_name, bones[i]);
-            }
-
-            model_shader->draw(mesh, scene_info, to_world);
-        }
+        // Otherwise use passed in shader.
+        Shader *shader_to_use = shader == nullptr ? model_shader : shader;
+        shader_to_use->use();
+        shader_to_use->draw(mesh, scene_info, to_world);
     }
 }
 
@@ -30,24 +19,18 @@ void Model::draw_instanced(Shader *shader, SceneInfo &scene_info,
                     std::vector<glm::mat4> &instance_matrix) {
     for (Mesh *mesh : meshes) {
         // Use model's attached shader if a NULL shader is passed in.
-        if (shader != nullptr) {
-            shader->use();
-            mesh->geometry->bind_instance_matrix(instance_matrix); // bind buffers on geometry
-            // Pass identity to_world matrix because using instance_matrix for every instance
-            shader->draw(mesh, scene_info, glm::mat4(1.f));
-        } else {
-            model_shader->use();
-            mesh->geometry->bind_instance_matrix(instance_matrix); // bind buffers on geometry
+        Shader *shader_to_use = shader == nullptr ? model_shader : shader;
+        shader_to_use->use();
+        mesh->geometry->bind_instance_matrix(instance_matrix); // bind buffers on geometry
+        // Pass identity to_world matrix because using instance_matrix for every instance
+        shader_to_use->draw(mesh, scene_info, glm::mat4(1.f));
+    }
+}
 
-            // Passes bones to shader manually to show that this model is animated
-            for (int i = 0; i < bones.size(); i++) {
-                char uni_name[128];
-                snprintf(uni_name, sizeof(uni_name), "bones[%d]", i);
-                model_shader->set_uni(uni_name, bones[i]);
-            }
-
-            model_shader->draw(mesh, scene_info, glm::mat4(1.f));
-        }
+void Model::set_model_filter(ModelFilter &filter) {
+    // Set all meshes' model filters.
+    for (Mesh *mesh : meshes) {
+        mesh->model_filter = filter;
     }
 }
 

--- a/src/model/model.h
+++ b/src/model/model.h
@@ -11,12 +11,11 @@
 #include "mesh.h"
 #include "scene/scene_info.h"
 #include "skeleton.h"
+#include "model_filter.h"
 
 class Model {
 private:
     Shader *model_shader;
-    std::vector<glm::mat4> bones; // Final transformation matrix for bones, including animation
-
 public:
     std::vector<Mesh *> meshes;
     Skeleton initial_skeleton; // Initial skeleton that model is compatible with, not updated.
@@ -29,13 +28,13 @@ public:
 
     void add_mesh(Mesh *m);
 
+    void set_model_filter(ModelFilter &filter);
+
     void set_color(Color color);
 
     void set_alpha(float alpha);
 
     void set_shadows(bool enable);
-
-    void set_bones(Skeleton *skel) { bones = skel->bones_final; };
 
     void set_shader(Shader *shader) { model_shader = shader; }
 };

--- a/src/model/model_filter.h
+++ b/src/model/model_filter.h
@@ -7,5 +7,9 @@ class ModelFilter {
 public:
     Skeleton skeleton;
     Material material;
-    bool material_filter = false;
+    // Flags to indicate which material fields are being overwritten
+    // There is certainly a better, more extensible way to do this
+    bool override_diffuse = false;
+    bool override_alpha = false;
+    bool override_shadows = false;
 };

--- a/src/model/model_filter.h
+++ b/src/model/model_filter.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "material.h"
+#include "skeleton.h"
+
+class ModelFilter {
+public:
+    Skeleton skeleton;
+    Material material;
+    bool material_filter = false;
+};

--- a/src/shaders/basic_shader.cpp
+++ b/src/shaders/basic_shader.cpp
@@ -34,12 +34,21 @@ void BasicShader::draw(Mesh *mesh, SceneInfo &scene_info, glm::mat4 to_world) {
     // Send mesh local transformation matrix.
     set_uni("mesh_model", mesh->local_transform);
 
-    // Send material. TODO: override from model_filter
-    set_uni("material.diffuse", mesh->material->diffuse.to_vec());
-    set_uni("material.specular", mesh->material->specular.to_vec());
-    set_uni("material.shininess", mesh->material->shininess);
-    set_uni("material.shadows_enabled", mesh->material->shadows);
-    set_uni("material.alpha", mesh->material->alpha);
+    // Send material.
+    // Override from model filter.
+    if (mesh->model_filter.material_filter) {
+        set_uni("material.diffuse", mesh->model_filter.material.diffuse.to_vec());
+        set_uni("material.specular", mesh->model_filter.material.specular.to_vec());
+        set_uni("material.shininess", mesh->model_filter.material.shininess);
+        set_uni("material.shadows_enabled", mesh->model_filter.material.shadows);
+        set_uni("material.alpha", mesh->model_filter.material.alpha);
+    } else {
+        set_uni("material.diffuse", mesh->material->diffuse.to_vec());
+        set_uni("material.specular", mesh->material->specular.to_vec());
+        set_uni("material.shininess", mesh->material->shininess);
+        set_uni("material.shadows_enabled", mesh->material->shadows);
+        set_uni("material.alpha", mesh->material->alpha);
+    }
 
     // Send texture uniforms.
     set_uni("texture_enabled", mesh->geometry->has_texture);

--- a/src/shaders/basic_shader.cpp
+++ b/src/shaders/basic_shader.cpp
@@ -21,11 +21,20 @@ void BasicShader::post_draw() {
 }
 
 void BasicShader::draw(Mesh *mesh, SceneInfo &scene_info, glm::mat4 to_world) {
+    char buf[128]; // hold uniform name as a char *, for perfomance when sending to shader.
+
+    /* BONES */
+    std::vector<glm::mat4> &bones = mesh->model_filter.skeleton.bones_final;
+    for (int i = 0; i < bones.size(); i++) {
+        sprintf(buf, "bones[%d]", i);
+        set_uni(buf, bones[i]);
+    }
+
     /* MESH UNIFORMS */
     // Send mesh local transformation matrix.
     set_uni("mesh_model", mesh->local_transform);
 
-    // Send material.
+    // Send material. TODO: override from model_filter
     set_uni("material.diffuse", mesh->material->diffuse.to_vec());
     set_uni("material.specular", mesh->material->specular.to_vec());
     set_uni("material.shininess", mesh->material->shininess);
@@ -50,7 +59,6 @@ void BasicShader::draw(Mesh *mesh, SceneInfo &scene_info, glm::mat4 to_world) {
 
     /* LIGHTS */
     // Send directional lights.
-    char buf[128]; // hold uniform name as a char *, for perfomance when sending to shader.
     char *uni_prefix = "dir_lights["; // Uniform prefix for directional light array.
     set_uni("num_dir_lights", (int) scene_info.dir_lights.size());
     for (int i = 0; i < scene_info.dir_lights.size(); ++i) {

--- a/src/shaders/basic_shader.cpp
+++ b/src/shaders/basic_shader.cpp
@@ -36,19 +36,18 @@ void BasicShader::draw(Mesh *mesh, SceneInfo &scene_info, glm::mat4 to_world) {
 
     // Send material.
     // Override from model filter.
-    if (mesh->model_filter.material_filter) {
-        set_uni("material.diffuse", mesh->model_filter.material.diffuse.to_vec());
-        set_uni("material.specular", mesh->model_filter.material.specular.to_vec());
-        set_uni("material.shininess", mesh->model_filter.material.shininess);
-        set_uni("material.shadows_enabled", mesh->model_filter.material.shadows);
-        set_uni("material.alpha", mesh->model_filter.material.alpha);
-    } else {
-        set_uni("material.diffuse", mesh->material->diffuse.to_vec());
-        set_uni("material.specular", mesh->material->specular.to_vec());
-        set_uni("material.shininess", mesh->material->shininess);
-        set_uni("material.shadows_enabled", mesh->material->shadows);
-        set_uni("material.alpha", mesh->material->alpha);
-    }
+    glm::vec3 diffuse = mesh->model_filter.override_diffuse ? mesh->model_filter.material.diffuse.to_vec() :
+                        mesh->material->diffuse.to_vec();
+    float alpha = mesh->model_filter.override_alpha ? mesh->model_filter.material.alpha :
+                  mesh->material->alpha;
+    bool shadows = mesh->model_filter.override_shadows ? mesh->model_filter.material.shadows :
+                   mesh->material->shadows;
+    set_uni("material.diffuse", diffuse);
+    set_uni("material.alpha", alpha);
+    set_uni("material.shadows_enabled", shadows);
+
+    set_uni("material.specular", mesh->material->specular.to_vec());
+    set_uni("material.shininess", mesh->material->shininess);
 
     // Send texture uniforms.
     set_uni("texture_enabled", mesh->geometry->has_texture);


### PR DESCRIPTION
- Every ``GameObject`` has its own ``ModelFilter``
- So every ``GameObject`` can override the skeleton and material properties of its model.
- The ``ModelFilter`` is passed down from the ``GameObject`` to the ``Model`` which passes it to all its ``Meshes``, then it is read by the shader accordingly.
- Provided every game object's animation player with a skeleton pointer at initialization so it doesn't need to pass in skeleton every time you want to set an animation.
- Cleaned up ``Model::draw`` and ``Model::draw_instanced``.