### PR TITLE
Fix some race conditions

### DIFF
--- a/src/game_objects/grid.cpp
+++ b/src/game_objects/grid.cpp
@@ -99,7 +99,6 @@ void Grid::setup_listeners() {
             auto position = std::find(children.begin(), children.end(), goal);
             if (position != children.end())
                 children.erase(position);
-            delete goal;
             goal = nullptr;
         }
         else {

--- a/src/net/connection.cpp
+++ b/src/net/connection.cpp
@@ -22,11 +22,11 @@ void Connection::start_async_read_header() {
 
 void Connection::start_async_read_body(uint32_t length) {
     rcvbuf.resize(length);
-    socket.async_read_some(boost::asio::buffer(rcvbuf.data(), length),
+    boost::asio::async_read(socket, boost::asio::buffer(rcvbuf.data(), length),
         [&, length](const boost::system::error_code& error, size_t n_bytes) {
         if (!error) {
             if (length != n_bytes) {
-                std::cerr << "ERROR: received unexpected num of bytes; dropping message\n";
+                std::cerr << "ERROR: received unexpected num of bytes (expected=" << length << ", got=" << n_bytes << ")\n";
             } else {
                 // Message body is the string offset by header size.
                 std::string body(rcvbuf.begin(), rcvbuf.end());


### PR DESCRIPTION
* Change `async_read_some` to `async_read`, since the former does not guarantee to fill the read buffer. 
 (source: http://stackoverflow.com/a/11084386/2014825)

* Don't free memory of goals, in case read updates are slow and we accidentally try to update the state of a Goal object whose memory has been freed.