### PR TITLE
Basic reconnection handling

### DIFF
--- a/src/net/network_server.cpp
+++ b/src/net/network_server.cpp
@@ -74,19 +74,19 @@ void NetworkServer::start_accept() {
 
     acceptor.async_accept(new_connection->get_socket(),
         [&, new_connection](const boost::system::error_code& error) {
-            int next_id = next_available_id();
             if (!error) {
                 std::cerr << "Accepted new connection." << std::endl;
-                unique_lock<mutex> lock(client_list_mutex);
-                client_list[next_id] = new_connection;
+                int next_id = next_available_id();
+                {
+                    unique_lock<mutex> lock(client_list_mutex);
+                    client_list[next_id] = new_connection;
+                }
                 new_connection->start_async_read_header();
+                events::menu::request_join_event(next_id);
             }
             else {
                 std::cerr << "accept() error: " << error << "," << error.message() << "\n";
             }
-
-            if (!error)
-                events::menu::request_join_event(next_id);
 
             // Accept the next client.
             start_accept();

--- a/src/net/network_server.h
+++ b/src/net/network_server.h
@@ -29,6 +29,9 @@ public:
     // Returns a mapping of client id to list of messages.
     std::unordered_map<int, std::vector<proto::ClientMessage>> read_all_messages();
 
+    // Get next free id in client_list. Starts at ID=1, and disconnects remove from the list.
+    int next_available_id();
+
 private:
     // Begin accepting new clients.
     void start_accept();
@@ -37,5 +40,4 @@ private:
     tcp::acceptor acceptor;
     std::unordered_map<int, boost::shared_ptr<Connection>> client_list;
     mutex client_list_mutex;
-    int next_id;
 };


### PR DESCRIPTION
Achieves this by reusing client ID's of clients who disconnect.

Note that this only allows you to reconnect/rejoin the game as **the most recent disconnected player** (if any).  It does not handle the case e.g. below:

- Client 1 joins as P1
- Client 2 joins as P2
- Client 1, Client 2 disconnect
- Client 2 tries to rejoin = joins as P1

Also, currently untested since I have no one to test with... will merge after I test and get approval.