### PR TITLE
Return to select grid when build phase starts

### DIFF
--- a/src/game/phase/build.cpp
+++ b/src/game/phase/build.cpp
@@ -10,6 +10,8 @@ void BuildPhase::setup() {
 
 void BuildPhase::client_setup() {
     events::build::start_build_event();
+    events::build::select_grid_return_event();
+    is_menu = true;
 
     joystick_conn = events::stick_event.connect([&](events::StickData d) {
 


### PR DESCRIPTION
Pls review 💨 ⏩ ⚡️ 

Resolves bug where preview construct is missing when you return to build phase.  This change makes the build phase always start with the menu (purchasing constructs) for consistency.