### PR TITLE
Reuse existing player if reconnecting

### DIFF
--- a/src/scene/main_scene.cpp
+++ b/src/scene/main_scene.cpp
@@ -67,6 +67,7 @@ Player* MainScene::spawn_new_player(int conn_id) {
     // TODO: determine where each player starts based on client id. 
     // For now, players 1-4 start at (2, 2), (2, 3), (2, 4), (2, 5) respectively.
     player->set_start_position({ 2.f, 0, 1.f + conn_id });
+    player->reset_position();
     objs.push_back(player);
 
     return player;
@@ -75,6 +76,7 @@ Player* MainScene::spawn_new_player(int conn_id) {
 Player* MainScene::spawn_existing_player(int obj_id) {
     Player *player = new Player(obj_id);
     player->transform.set_scale({ 0.004f, 0.004f, 0.004f });
+    player->transform.translate({ 2.f, 0.f, 2.f });
     objs.push_back(player);
     
     Model *player_model = AssetLoader::get_model(std::string("cat"));


### PR DESCRIPTION
If we're reconnecting to an existing player after disconnect, then don't spawn a new player -- use the re-existing one.