### PR TITLE
Chest disappears after opening, and comes back on build phase

### DIFF
--- a/src/game/phase/build.cpp
+++ b/src/game/phase/build.cpp
@@ -13,6 +13,13 @@ void BuildPhase::s_setup() {
     for (int id : context.player_ids) {
         context.ready_flags[id] = false;
     }
+
+    // Re-enable chests on server side.
+    for (auto & kv : GameObject::game_objects) {
+        if (dynamic_cast<Chest*>(kv.second)) {
+            kv.second->enable();
+        }
+    }
 }
 
 void BuildPhase::c_setup() {
@@ -114,6 +121,14 @@ void BuildPhase::c_setup() {
     // Play music
     events::AudioData d = { AudioManager::BUILD_MUSIC };
     events::music_event(d);
+
+    // Make opened chests reappear at start of build phase.
+    for (auto & kv : GameObject::game_objects) {
+        if (dynamic_cast<Chest*>(kv.second)) {
+            kv.second->set_filter_alpha(1.f);
+            kv.second->enable();
+        }
+    }
 }
 
 proto::Phase BuildPhase::s_update() {

--- a/src/game_objects/construct.cpp
+++ b/src/game_objects/construct.cpp
@@ -40,6 +40,7 @@ void Chest::s_interact_trigger(GameObject *other) {
     }
 
     // Chest will fade away, no longer needs rigid body
+    // TODO : Change to Disable() once Client Animation Finishes
     events::disable_rigidbody_event(this);
 
     // Send signal to client to tell that this chest is opened
@@ -50,7 +51,7 @@ void Chest::s_interact_trigger(GameObject *other) {
 void Chest::c_interact_trigger(GameObject *other) {
     anim_player.play_if_paused("open");
 
-    Timer::get()->do_after(std::chrono::seconds(1),
+    Timer::get()->do_after(std::chrono::milliseconds(500),
         [&]() {
         disappear();
     });
@@ -63,19 +64,16 @@ void Chest::setup_model() {
 
 // Causes chest to slowly fade away, Client
 void Chest::disappear() {
-    set_alpha(0.0f);
     int count = 0;
     cancel_fade = Timer::get()->do_every(
         std::chrono::milliseconds(100),
         [&, count]() mutable {
-        const int num_steps = 20;
-        if (count < num_steps) {
-            //set_filter_alpha(0.1f);
-            std::cerr << "Test" << count << std::endl;
+        const float num_steps = 20;
+        if (count <= num_steps) {
+           set_filter_alpha(1.f - (count / num_steps));
         }
         else {
             cancel_fade();
-            disable();
         }
         count++;
     });

--- a/src/game_objects/construct.cpp
+++ b/src/game_objects/construct.cpp
@@ -41,7 +41,10 @@ void Chest::s_interact_trigger(GameObject *other) {
 
     // Chest will fade away, no longer needs rigid body
     // TODO : Change to Disable() once Client Animation Finishes
-    events::disable_rigidbody_event(this);
+    Timer::get()->do_after(std::chrono::milliseconds(1500), [&]() {
+        events::disable_rigidbody_event(this);
+        disable();
+    });
 
     // Send signal to client to tell that this chest is opened
     events::dungeon::network_interact_event(other->get_id(), id);
@@ -66,13 +69,14 @@ void Chest::setup_model() {
 void Chest::disappear() {
     int count = 0;
     cancel_fade = Timer::get()->do_every(
-        std::chrono::milliseconds(100),
+        std::chrono::milliseconds(50),
         [&, count]() mutable {
         const float num_steps = 20;
         if (count <= num_steps) {
            set_filter_alpha(1.f - (count / num_steps));
         }
         else {
+            anim_player.stop();
             cancel_fade();
         }
         count++;

--- a/src/game_objects/construct.cpp
+++ b/src/game_objects/construct.cpp
@@ -42,7 +42,6 @@ void Chest::s_interact_trigger(GameObject *other) {
     // Chest will fade away, no longer needs rigid body
     // TODO : Change to Disable() once Client Animation Finishes
     Timer::get()->do_after(std::chrono::milliseconds(1500), [&]() {
-        events::disable_rigidbody_event(this);
         disable();
     });
 

--- a/src/game_objects/construct.h
+++ b/src/game_objects/construct.h
@@ -34,9 +34,12 @@ public:
     void s_interact_trigger(GameObject *other) override;
     void c_interact_trigger(GameObject *other) override;
 
+    void disappear(); // Causes chest to fade away
 private:
     btBoxShape *hit_box = new btBoxShape(btVector3(0.5f, 0.5f, 0.5f));
     std::unique_ptr<collectibles::Collectible> contents;
+
+    std::function<void()> cancel_fade; // Callback function to cancel fading away.
 };
 
 class Goal : public Construct {


### PR DESCRIPTION
Authored by @AustinPuk, co-authored by me.

When a player interacts with chest:
* remove rigid body
* animate its transparency to 0
* disable it

When build phase starts:
* re-enable the chest