### PR TITLE
Collision Masks

### DIFF
--- a/src/collision_groups.h
+++ b/src/collision_groups.h
@@ -1,0 +1,13 @@
+#pragma once
+
+// Header only to globally define collision groups
+
+#define BIT(x) (1<<(x))
+
+// ONLY 15 FILTERS SUPPORTED!
+enum CollisionGroup {
+    COLLISION_NONE = 0,
+    COLLISION_DEFAULT = BIT(0),
+    COLLISION_ESSENCE = BIT(1),
+    COLLISION_SLIME = BIT(2)
+};

--- a/src/events.h
+++ b/src/events.h
@@ -7,6 +7,7 @@
 #include "game/direction.h"
 #include "game/context.h"
 #include "btBulletDynamicsCommon.h"
+#include "collision_groups.h"
 
 // Forward declaration to resolve circular dependency.
 class GameObject;
@@ -127,6 +128,9 @@ namespace events {
         float mass = 0.0f;
         glm::vec3 inertia = glm::vec3(0.0f);
         glm::vec3 position = glm::vec3(0.0f); // Initial position
+        short collision_group = COLLISION_DEFAULT;
+        short collision_mask = 0; // collides with everything by default.
+                                  // OR (| operator) with groups to not collide with them
     };
 
     extern signal<void(RigidBodyData d)> add_rigidbody_event;

--- a/src/game_objects/essence.cpp
+++ b/src/game_objects/essence.cpp
@@ -8,6 +8,8 @@
 #include "game/collectibles/gold.h"
 #include "game/collectibles/nothing.h"
 
+#include "collision_groups.h"
+
 #include <iostream>
 
 Essence::Essence(int id) : GameObject(id){
@@ -22,6 +24,8 @@ Essence::Essence(int id) : GameObject(id){
         rigid.object = this;
         rigid.shape = hit_sphere;
         rigid.mass = 1;
+        rigid.collision_group = COLLISION_ESSENCE;
+        rigid.collision_mask |= COLLISION_ESSENCE; // don't collide with own kind
         events::add_rigidbody_event(rigid);
         notify_on_collision = true;
 

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -2,6 +2,8 @@
 #include "scene/scene.h"
 #include "aldente_client.h"
 
+#define ALL_FILTER -1
+
 Physics::Physics() {
     // Initialize Bullet. This strictly follows http://bulletphysics.org/mediawiki-1.5.8/index.php/Hello_World,
     // even though we won't use most of this stuff.
@@ -203,7 +205,7 @@ void Physics::add_rigid(events::RigidBodyData d) {
     if (d.is_ghost)
         rigidbody->setCollisionFlags(btCollisionObject::CF_NO_CONTACT_RESPONSE);
 
-    dynamicsWorld->addRigidBody(rigidbody);
+    dynamicsWorld->addRigidBody(rigidbody, d.collision_group, ALL_FILTER ^ d.collision_mask);
 }
 
 void Physics::remove_rigid(GameObject *obj) {


### PR DESCRIPTION
- By default, objects are in the default group (COLLISION_DEFAULT in collision_groups.h)
- By default, objects collide with every group (see ALL_FILTER = -1 in physics.cpp)
- To give special collision treatment to certain objects, give it its own collision group (NOTE: A MAX OF 15 custom collision groups)
- To make objects NOT collide with certain groups, do a bitwise or with its rigid.collision_mask (see essence.cpp for an example of it not colliding with other essences).