### PR TITLE
Strip grid events

### DIFF
--- a/src/events.cpp
+++ b/src/events.cpp
@@ -24,8 +24,6 @@ namespace events {
         signal<void()> toggle_ui_text_box_background_event;
     }
 
-    signal<void(int)> ui_grid_selection_event;
-    signal<void(int)> ui_grid_movement_event;
     signal<void(RigidBodyData d)> add_rigidbody_event;
     signal<void(GameObject *obj)> remove_rigidbody_event;
     signal<void(GameObject *obj)> disable_rigidbody_event;

--- a/src/events.h
+++ b/src/events.h
@@ -115,10 +115,6 @@ namespace events {
         extern signal<void()> toggle_ui_text_box_background_event;
     }
 
-    // The user has made a selection on the UI grid.
-    extern signal<void(int)> ui_grid_selection_event;
-    extern signal<void(int)> ui_grid_movement_event;
-
     // Struct for parameters for rigidbody initialization
     struct RigidBodyData {
         GameObject *object = nullptr; //Object that has the rigidBody

--- a/src/ui/build_ui.cpp
+++ b/src/ui/build_ui.cpp
@@ -48,11 +48,25 @@ BuildUI::BuildUI(int num_cols, int num_rows, float aspect, std::vector<Construct
     // Display info of first element by default.
     update_info_panel(0);
 
-    events::ui_grid_movement_event.connect([&](int content_index) {
-        update_info_panel(content_index);
+    // Build UI disable/enable triggers.
+    // Enables Build UI on the start of the build phase
+    events::build::start_build_event.connect([&]() {
+        enable();
     });
 
-    events::ui_grid_selection_event.connect([&](int content_index) {
+    // Disables Build UI at the end of the build phase
+    events::build::end_build_event.connect([&]() {
+        disable();
+    });
+
+    events::build::select_grid_move_event.connect([&](Direction dir) {
+        ui_grid.move_selection(dir);
+        update_info_panel(ui_grid.get_selection_index());
+    });
+
+    events::build::select_grid_confirm_event.connect([&]() {
+        // Tell the dungeon grid what construct was selected.
+        int content_index = ui_grid.get_selection_index();
         events::build::c_check_funds_event(this->constructs[content_index].type);
     });
 
@@ -61,6 +75,8 @@ BuildUI::BuildUI(int num_cols, int num_rows, float aspect, std::vector<Construct
         shop_panel.disable();
         player_panel.disable();
     });
+
+    // Show the grid.
     events::build::select_grid_return_event.connect([&]() {
         shop_panel.enable();
         player_panel.enable();

--- a/src/ui/ui_grid.cpp
+++ b/src/ui/ui_grid.cpp
@@ -61,16 +61,10 @@ UIGrid::UIGrid(float start_x, float start_y,
 
     // First item in grid is selected by default (0,0)
     toggle_current_selection_halo();
+}
 
-    // Set up callbacks.
-    events::build::select_grid_move_event.connect([&, columns](Direction dir) {
-        move_selection(dir);
-        events::ui_grid_movement_event(selection_row * columns + selection_col);
-    });
-
-    events::build::select_grid_confirm_event.connect([&, columns]() {
-        events::ui_grid_selection_event(selection_row * columns + selection_col);
-    });
+int UIGrid::get_selection_index() {
+    return selection_row * columns + selection_col;
 }
 
 void UIGrid::attach_at(int row, int col, UIElement &child) {

--- a/src/ui/ui_grid.h
+++ b/src/ui/ui_grid.h
@@ -24,8 +24,9 @@ public:
         float offset_x, float offset_y) override;
     void enable() override;
     void disable() override;
-private:
+    int get_selection_index(); // returns the grid index of the current selection
     void move_selection(Direction d);
+private:
     void toggle_current_selection_halo();
 
     float grid_width, grid_height; // size of entire grid rectangle

--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -50,17 +50,6 @@ void UIManager::setup_listeners() {
     events::debug::toggle_ui_event.connect([&](void) {
         all_enabled = !all_enabled;
     });
-
-    // Build UI disable/enable triggers.
-    // Enables Build UI on the start of the build phase
-    events::build::start_build_event.connect([&]() {
-        ui_map["build"]->enable(); // TODO: assert that ui_map["build"] exists?
-    });
-
-    // Disables Build UI at the end of the build phase
-    events::build::end_build_event.connect([&]() {
-        ui_map["build"]->disable();
-    });
 }
 
 void UIManager::draw() {


### PR DESCRIPTION
Moved ui_grid listeners to build_ui. Moved build_ui enable/disable listeners from ui_manager to build_ui. Removed unnecessary events.