### PR TITLE
Change to using Transform for direction

### DIFF
--- a/src/components/transform.cpp
+++ b/src/components/transform.cpp
@@ -166,3 +166,14 @@ glm::mat4 Transform::get_rotation_mat() {
 glm::mat4 Transform::get_scale_mat() {
     return glm::scale(glm::mat4(1.f), get_scale());
 }
+
+// Get basis vectors from world matrix
+glm::vec3 Transform::get_forward() {
+    return glm::vec3(world_mat[2][0], world_mat[2][1], world_mat[2][2]);
+}
+glm::vec3 Transform::get_up() {
+    return glm::vec3(world_mat[1][0], world_mat[1][1], world_mat[1][2]);
+}
+glm::vec3 Transform::get_right() {
+    return glm::vec3(world_mat[0][0], world_mat[0][1], world_mat[0][2]);
+}

--- a/src/components/transform.cpp
+++ b/src/components/transform.cpp
@@ -30,9 +30,9 @@ void Transform::set_rotation(glm::vec3 angles) {
 // Starting from the object's original orientatin, rotates around the x-axis,
 // then y-axis, then z-axis.
 void Transform::set_rotation(float x, float y, float z) {
-    glm::mat4 rotate_x = glm::rotate(glm::mat4(1.0f), x, glm::vec3(1.f, 0.f, 0.f));
-    glm::mat4 rotate_y = glm::rotate(glm::mat4(1.0f), y, glm::vec3(0.f, 1.f, 0.f));
-    glm::mat4 rotate_z = glm::rotate(glm::mat4(1.0f), z, glm::vec3(0.f, 0.f, 1.f));
+    glm::mat4 rotate_x = glm::rotate(glm::mat4(1.0f), glm::radians(x), glm::vec3(1.f, 0.f, 0.f));
+    glm::mat4 rotate_y = glm::rotate(glm::mat4(1.0f), glm::radians(y), glm::vec3(0.f, 1.f, 0.f));
+    glm::mat4 rotate_z = glm::rotate(glm::mat4(1.0f), glm::radians(z), glm::vec3(0.f, 0.f, 1.f));
 
     glm::mat4 rotation = rotate_z * rotate_y * rotate_x;
 
@@ -76,9 +76,9 @@ void Transform::rotate(float x, float y, float z, bool local) {
     if (local)
         translate(-current_pos);
 
-    glm::mat4 rotate_x = glm::rotate(glm::mat4(1.0f), x, glm::vec3(1.f, 0.f, 0.f));
-    glm::mat4 rotate_y = glm::rotate(glm::mat4(1.0f), y, glm::vec3(0.f, 1.f, 0.f));
-    glm::mat4 rotate_z = glm::rotate(glm::mat4(1.0f), z, glm::vec3(0.f, 0.f, 1.f));
+    glm::mat4 rotate_x = glm::rotate(glm::mat4(1.0f), glm::radians(x), glm::vec3(1.f, 0.f, 0.f));
+    glm::mat4 rotate_y = glm::rotate(glm::mat4(1.0f), glm::radians(y), glm::vec3(0.f, 1.f, 0.f));
+    glm::mat4 rotate_z = glm::rotate(glm::mat4(1.0f), glm::radians(z), glm::vec3(0.f, 0.f, 1.f));
     glm::mat4 rotation = rotate_z * rotate_y * rotate_x;
 
     world_mat = rotation * world_mat;

--- a/src/components/transform.h
+++ b/src/components/transform.h
@@ -33,6 +33,10 @@ public:
     glm::vec3 get_rotation();
     glm::vec3 get_scale();
 
+    glm::vec3 get_forward();
+    glm::vec3 get_up();
+    glm::vec3 get_right();
+
 private:
     glm::mat4 world_mat;
 

--- a/src/game_objects/construct.cpp
+++ b/src/game_objects/construct.cpp
@@ -8,6 +8,7 @@
 Construct::Construct(int x, int z, int id) : GameObject(id) {
     tag = "CONSTRUCT";
     set_position({ x, 0.0f, z });
+    initial_transform.set_position({ x, 0.0f, z });
 }
 
 /************CHEST***************/
@@ -63,6 +64,7 @@ void Chest::c_interact_trigger(GameObject *other) {
 void Chest::setup_model() {
     attach_model(AssetLoader::get_model("chest_good"));
     transform.set_scale({ 0.006f, 0.006f, 0.006f });
+    initial_transform.set_scale(transform.get_scale());
 }
 
 // Causes chest to slowly fade away, Client
@@ -121,6 +123,7 @@ void Spikes::c_on_collision(GameObject *other) {
 void Spikes::setup_model() {
     attach_model(AssetLoader::get_model("spikes"));
     transform.set_scale({ 0.4f, 0.4f, 0.4f });
+    initial_transform.set_scale(transform.get_scale());
 }
 
 /************GOAL***************/
@@ -142,6 +145,7 @@ Goal::Goal(int x, int z, int id) : Construct(x, z, id) {
 void Goal::setup_model() {
     attach_model(AssetLoader::get_model("warp"));
     transform.set_scale(0.006f, 0.006f, 0.006f);
+    initial_transform.set_scale(transform.get_scale());
     anim_player.set_speed(1.0f);
     anim_player.set_anim("spin");
     anim_player.set_loop(true);

--- a/src/game_objects/game_object.cpp
+++ b/src/game_objects/game_object.cpp
@@ -16,7 +16,6 @@ GameObject::GameObject(int id) : id(id) {
     model = new Model();
     rigidbody = nullptr;
     game_objects[this->id] = this;
-    direction = glm::vec3(0.0f);
     enabled = true;
 }
 
@@ -82,9 +81,7 @@ void GameObject::c_update_state(float x, float z, float wx, float wz, bool enab)
     enabled = enab;
     if (enabled) {
         transform.set_position(x, 0.0f, z);
-        direction = glm::vec3(wx, 0, wz);
-        transform.look_at(direction);
-
+        transform.look_at({ wx, 0, wz });
         anim_player.update();
     }
 }
@@ -143,7 +140,10 @@ void GameObject::set_shadows(bool enable) {
 void GameObject::set_position(glm::vec3 pos) {
     // Set for Transform
     transform.set_position(pos);
+    set_rb_position(pos);
+}
 
+void GameObject::set_rb_position(glm::vec3 pos) {
     // Set for Rigid Body
     btTransform initialTransform;
 

--- a/src/game_objects/game_object.h
+++ b/src/game_objects/game_object.h
@@ -32,6 +32,8 @@ protected:
     AnimationPlayer anim_player;
     btRigidBody *rigidbody;
 
+    Transform initial_transform; // Initial transform to reset to at beginning of build phase
+
     int id;
     bool enabled;
 
@@ -41,7 +43,6 @@ public:
     std::vector<GameObject *> children;
 
     Transform transform; // World matrix now controlled using the Transform Component
-    glm::vec3 direction; // Direction the object is facing
     std::string tag; // Identify this GameObject by a human-readable tag.
     bool notify_on_collision = false; // Physics engine will only call on_collision if this flag is set.
 
@@ -91,6 +92,9 @@ public:
 
     // Sets both transform and rigid body position at the same time
     void set_position(glm::vec3 pos);
+
+    // Sets only rigidbody's position
+    void set_rb_position(glm::vec3 pos);
 
     void set_ghost(bool b);
     void disable();

--- a/src/game_objects/player.h
+++ b/src/game_objects/player.h
@@ -27,8 +27,6 @@ private:
 
     float move_speed;
 
-    glm::vec3 start_pos;
-
     bool exiting;
     bool is_client;
 

--- a/src/net/network_manager.cpp
+++ b/src/net/network_manager.cpp
@@ -54,8 +54,8 @@ void ServerNetworkManager::register_listeners() {
             go->set_model_index(player->c_get_model_index());
             go->set_x(player->transform.get_position().x);
             go->set_z(player->transform.get_position().z);
-            go->set_wx(player->direction.x);
-            go->set_wz(player->direction.z);
+            go->set_wx(player->transform.get_forward().x);
+            go->set_wz(player->transform.get_forward().z);
             go->set_enabled(player->is_enabled());
         }
         
@@ -92,8 +92,8 @@ void ServerNetworkManager::register_listeners() {
 
             go->set_x(obj->transform.get_position().x);
             go->set_z(obj->transform.get_position().z);
-            go->set_wx(obj->direction.x);
-            go->set_wz(obj->direction.z);
+            go->set_wx(obj->transform.get_forward().x);
+            go->set_wz(obj->transform.get_forward().z);
             go->set_enabled(obj->is_enabled());
         }
 


### PR DESCRIPTION
So instead of having 'direction' for game objects to tell which direction they are facing, you can just use 'transform.get_forward()'.

This allows the transform and all rotation stuff to handle the direction for you, and will make it easier to reset game object's positions.

Also, it may be a good idea later to replace how Camera is handled using a Transform now.