### PR TITLE
Implement modal inputs

### DIFF
--- a/src/aldente_client.cpp
+++ b/src/aldente_client.cpp
@@ -1,3 +1,4 @@
+#include <input/modal_input.h>
 #include "aldente_client.h"
 
 #include "window.h"
@@ -65,6 +66,7 @@ void AldenteClient::start() {
             input::BTN_MAP_XBOX;
     input::ConceptualTranslator translator(control_mapping, input::KBD_MAP_DEBUG);
     input::AxisCombiner stick_handler(translator, input::STICKS_DEFAULT);
+    input::ModalInput::provide(std::make_shared<input::ModalInput>());
 
     // Setup subsystems after window creation.
     glSetup();

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -83,7 +83,7 @@ namespace events {
         signal<void(glm::vec3, glm::vec3, std::function<void(GameObject *bt_hit)>)> request_raycast_event;
         signal<void(glm::vec3)> player_position_updated_event;
         signal<void()> s_prepare_dungeon_event;
-        signal<void(StickData &)> network_player_move_event;
+        signal<void(const StickData &)> network_player_move_event;
         signal<void(Context*)> update_state_event;
         signal<void(int, int)> network_collision_event;
         signal<void()> player_interact_event;

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -2,9 +2,9 @@
 
 namespace events {
     using boost::signals2::signal;
-    signal<void(JoystickData &)> joystick_event;
-    signal<void(ButtonData &)> button_event;
-    signal<void(StickData &)> stick_event;
+    signal<void(const JoystickData &)> joystick_event;
+    signal<void(const ButtonData &)> button_event;
+    signal<void(const StickData &)> stick_event;
     signal<void(const AudioData &)> music_event;
     signal<void(const AudioData &)> sound_effects_event;
     signal<void(std::string)> stop_sound_effects_event;

--- a/src/events.h
+++ b/src/events.h
@@ -250,7 +250,7 @@ namespace events {
         extern signal<void()> s_prepare_dungeon_event;
 
         // Client requests the server to move player, passing its input stick data.
-        extern signal<void(StickData &)> network_player_move_event;
+        extern signal<void(const StickData &)> network_player_move_event;
 
         // Server sends context containing position, collisions, and interactions of game objects to all clients.
         extern signal<void(Context*)> update_state_event;

--- a/src/events.h
+++ b/src/events.h
@@ -28,7 +28,7 @@ namespace events {
         int state; // If button, zero is not pressed, nonzero is pressed.
         // Otherwise, is axis analog level.
     };
-    extern signal<void(JoystickData &)> joystick_event;
+    extern signal<void(const JoystickData &)> joystick_event;
 
     // Conceptual button input
     enum ConceptualButton {
@@ -47,7 +47,7 @@ namespace events {
         int state; // If button, zero is not pressed, nonzero is pressed.
         // Otherwise, is axis analog level.
     };
-    extern signal<void(ButtonData &)> button_event;
+    extern signal<void(const ButtonData &)> button_event;
 
     // Stick
     enum Stick {
@@ -58,7 +58,7 @@ namespace events {
         Stick input;
         std::pair<int, int> state;
     };
-    extern signal<void(StickData &)> stick_event;
+    extern signal<void(const StickData &)> stick_event;
 
     // Audio
     struct AudioData {

--- a/src/game/phase/build.cpp
+++ b/src/game/phase/build.cpp
@@ -1,4 +1,5 @@
 #include <game/game_state.h>
+#include <input/modal_input.h>
 #include "build.h"
 #include "audio/audio_manager.h"
 
@@ -45,7 +46,7 @@ void BuildPhase::c_setup() {
     events::build::select_grid_return_event();
     is_menu = true;
 
-    joystick_conn = events::stick_event.connect([&](events::StickData d) {
+    joystick_conn = input::ModalInput::get()->with_mode(input::ModalInput::NORMAL).sticks.connect([&](events::StickData d) {
 
         // Left stick for UI Grid Movement
         if (d.input == events::STICK_LEFT) {
@@ -76,7 +77,7 @@ void BuildPhase::c_setup() {
         }
     });
 
-    button_conn = events::button_event.connect([&](events::ButtonData d) {
+    button_conn = input::ModalInput::get()->with_mode(input::ModalInput::NORMAL).buttons.connect([&](events::ButtonData d) {
         Direction dir;
         bool d_pad = false;
 

--- a/src/game/phase/build.cpp
+++ b/src/game/phase/build.cpp
@@ -46,7 +46,7 @@ void BuildPhase::c_setup() {
     events::build::select_grid_return_event();
     is_menu = true;
 
-    joystick_conn = input::ModalInput::get()->with_mode(input::ModalInput::NORMAL).sticks.connect([&](events::StickData d) {
+    joystick_conn = input::ModalInput::get()->with_mode(input::ModalInput::NORMAL).sticks.connect([&](const events::StickData &d) {
 
         // Left stick for UI Grid Movement
         if (d.input == events::STICK_LEFT) {
@@ -77,7 +77,7 @@ void BuildPhase::c_setup() {
         }
     });
 
-    button_conn = input::ModalInput::get()->with_mode(input::ModalInput::NORMAL).buttons.connect([&](events::ButtonData d) {
+    button_conn = input::ModalInput::get()->with_mode(input::ModalInput::NORMAL).buttons.connect([&](const events::ButtonData &d) {
         Direction dir;
         bool d_pad = false;
 

--- a/src/game/phase/dungeon.cpp
+++ b/src/game/phase/dungeon.cpp
@@ -49,14 +49,14 @@ void DungeonPhase::s_setup() {
 
 void DungeonPhase::c_setup() {
     context.player_finished = false;
-    joystick_conn = input::ModalInput::get()->with_mode(input::ModalInput::NORMAL).sticks.connect([&](events::StickData d) {
+    joystick_conn = input::ModalInput::get()->with_mode(input::ModalInput::NORMAL).sticks.connect([&](const events::StickData &d) {
         // Left stick
         if (d.input == events::STICK_LEFT) {
             events::dungeon::network_player_move_event(d);
         }
     });
 
-    button_conn = input::ModalInput::get()->with_mode(input::ModalInput::NORMAL).buttons.connect([&](events::ButtonData d) {
+    button_conn = input::ModalInput::get()->with_mode(input::ModalInput::NORMAL).buttons.connect([&](const events::ButtonData &d) {
         if (d.state == 0) return;
         switch (d.input) {
             case events::BTN_A:

--- a/src/game/phase/dungeon.cpp
+++ b/src/game/phase/dungeon.cpp
@@ -1,4 +1,5 @@
 #include <game/game_state.h>
+#include <input/modal_input.h>
 #include "dungeon.h"
 #include "game_objects/player.h"
 #include "game_objects/essence.h"
@@ -48,14 +49,14 @@ void DungeonPhase::s_setup() {
 
 void DungeonPhase::c_setup() {
     context.player_finished = false;
-    joystick_conn = events::stick_event.connect([&](events::StickData d) {
+    joystick_conn = input::ModalInput::get()->with_mode(input::ModalInput::NORMAL).sticks.connect([&](events::StickData d) {
         // Left stick
         if (d.input == events::STICK_LEFT) {
             events::dungeon::network_player_move_event(d);
         }
     });
 
-    button_conn = events::button_event.connect([&](events::ButtonData d) {
+    button_conn = input::ModalInput::get()->with_mode(input::ModalInput::NORMAL).buttons.connect([&](events::ButtonData d) {
         if (d.state == 0) return;
         switch (d.input) {
             case events::BTN_A:

--- a/src/input/modal_input.cpp
+++ b/src/input/modal_input.cpp
@@ -1,0 +1,16 @@
+#include "modal_input.h"
+
+namespace input {
+
+std::shared_ptr<ModalInput> ModalInput::instance;
+
+ModalInput::ModalInput() : current_mode(NORMAL) {
+    events::button_event.connect([&](const events::ButtonData d) {
+        with_mode(current_mode).buttons(d);
+    });
+    events::stick_event.connect([&](const events::StickData d) {
+        with_mode(current_mode).sticks(d);
+    });
+}
+
+}

--- a/src/input/modal_input.cpp
+++ b/src/input/modal_input.cpp
@@ -5,10 +5,10 @@ namespace input {
 std::shared_ptr<ModalInput> ModalInput::instance;
 
 ModalInput::ModalInput() : current_mode(NORMAL) {
-    events::button_event.connect([&](const events::ButtonData d) {
+    events::button_event.connect([&](const events::ButtonData &d) {
         with_mode(current_mode).buttons(d);
     });
-    events::stick_event.connect([&](const events::StickData d) {
+    events::stick_event.connect([&](const events::StickData &d) {
         with_mode(current_mode).sticks(d);
     });
 }

--- a/src/input/modal_input.h
+++ b/src/input/modal_input.h
@@ -1,0 +1,39 @@
+#pragma once
+#include "boost/signals2.hpp"
+#include "events.h"
+
+namespace input {
+
+// Modal indirection for input dispatching.
+class ModalInput {
+public:
+    // The list of input modes.
+    enum InputMode {
+        NORMAL, DIALOG,
+    };
+
+    // A pair of signals for button and stick events.
+    struct InputSignals {
+        boost::signals2::signal<void(const events::ButtonData &)> buttons;
+        boost::signals2::signal<void(const events::StickData &)> sticks;
+    };
+
+    ModalInput();
+
+    // Singleton injection.
+    static void provide(std::shared_ptr<ModalInput> p) { instance = p; }
+    static std::shared_ptr<ModalInput> get() { return instance; }
+
+    void set_mode(InputMode mode) { current_mode = mode; }
+
+    // Used to subscribe to input signals.
+    // Example:
+    InputSignals &with_mode(InputMode mode) { return signals[mode]; };
+
+private:
+    static std::shared_ptr<ModalInput> instance;
+    InputMode current_mode;
+    std::map<InputMode, InputSignals> signals;
+};
+
+}


### PR DESCRIPTION
From now on, please specify the mode for which you want to listen to input events as follows:

```c++
// Instead of...
events::button_event.connect(...):

// Use this if we want to listen to buttons on DIALOG mode...
input::ModalInput::get()->with_mode(input::ModalInput::DIALOG).buttons.connect(...);
```

It's a bit verbose because of namespacing, so suggestions are welcome.