### PR TITLE
Fully functional dialogue boxes

### DIFF
--- a/src/events.cpp
+++ b/src/events.cpp
@@ -66,6 +66,7 @@ namespace events {
         signal<void()> disable_leaderboard;
         signal<void()> enable_leaderboard;
         signal<void(int, int, std::string)> leaderboard_update;
+        signal<void(const std::vector<std::pair<std::string, std::string>> &)> show_dialog;
     }
 
     namespace build {

--- a/src/events.h
+++ b/src/events.h
@@ -193,6 +193,7 @@ namespace events {
         extern signal<void(int, int, std::string)> leaderboard_update;
 
         // Request some dialog to be shown
+        // Show a sequence of dialog with events::ui::show_dialog({{portrait_str, text}, ...}).
         extern signal<void(const std::vector<std::pair<std::string, std::string>> &)> show_dialog;
     }
 

--- a/src/events.h
+++ b/src/events.h
@@ -191,6 +191,9 @@ namespace events {
         extern signal<void()> disable_leaderboard;
         extern signal<void()> enable_leaderboard;
         extern signal<void(int, int, std::string)> leaderboard_update;
+
+        // Request some dialog to be shown
+        extern signal<void(const std::vector<std::pair<std::string, std::string>> &)> show_dialog;
     }
 
     namespace build {

--- a/src/ui/dialog_ui.cpp
+++ b/src/ui/dialog_ui.cpp
@@ -1,5 +1,8 @@
 #include <asset_loader.h>
 #include "dialog_ui.h"
+#include "timer.h"
+#include "events.h"
+#include "input/modal_input.h"
 
 DialogUI::DialogUI(float aspect, float width, float height, float padding)
     : bg(0, 0, aspect * 100.f, 100.f, Color::BLACK, 0.8f)
@@ -7,10 +10,108 @@ DialogUI::DialogUI(float aspect, float width, float height, float padding)
               aspect * (100.f - width) / 2 + height, // Center, but make room for the portrait
               padding, aspect * width - height, height, padding,
               UIUnstretchedTextBox::START, UIUnstretchedTextBox::START, Color::WHITE, Color::BLACK, 0.5f)
-    , portrait(aspect * (100.f - width) / 2, padding, height, height, AssetLoader::get_texture("dio.jpg")) {
+    , portrait(aspect * (100.f - width) / 2, padding, height, height, AssetLoader::get_texture("dio.jpg"))
+    , cancel_text_animation([](){})
+    , animating(false) {
+
+    // Don't show by default
     disable();
     attach(bg);
     attach(portrait);
     attach(textbox);
-    textbox.set_text("hellotestthisisaprettylongstringihope it will display correctly please help");
+
+    events::ui::show_dialog.connect([&](const auto &sequence) {
+        // Start displaying text
+        enable();
+        current_dialog = sequence;
+        std::reverse(current_dialog.begin(), current_dialog.end()); // Reverse so we can pop_back
+        display_next();
+
+        // Switch to dialog bindings and recieve button presses
+        const auto &mi = input::ModalInput::get();
+        mi->set_mode(input::ModalInput::DIALOG);
+        button_conn = mi->with_mode(input::ModalInput::DIALOG).buttons.connect([&](const events::ButtonData &d) {
+            if (d.state) {
+                if (animating)
+                    skip_animation();
+                else
+                    display_next();
+            }
+        });
+    });
+
+}
+
+void DialogUI::display_next() {
+    size_t max = textbox.get_max_chars();
+
+    // Reset the text box
+    display = "";
+
+    // If we had no overflow from before, bring in the next dialogue
+    if (overflow.empty()) {
+        // If no next, just stop
+        if (current_dialog.empty()) {
+            stop_display();
+            return;
+        }
+
+        // Grab the next portrait and text
+        std::string portrait_str;
+        std::tie(portrait_str, remain) = current_dialog.back();
+        current_dialog.pop_back();
+
+        // Set the portrait
+        portrait.set_image(AssetLoader::get_texture(portrait_str));
+
+        // If we exceed the textbox capacity, break it up
+        if (remain.length() > max) {
+            overflow = remain.substr(max - 1);
+            remain = remain.substr(0, max - 1) + "-";
+        }
+    } else {
+        // Make room for possible hyphenation
+        remain = overflow.substr(0, max - 1);
+
+        // If we have no more text, unset overflow
+        if (overflow.length() <= max) {
+            overflow = "";
+
+            // If we're right at the max, add the last character in
+            if (overflow.length() == max)
+                remain += overflow[max - 1];
+        // Otherwise, we should adjust overflow and hyphenate
+        } else {
+            overflow = overflow.substr(max - 1);
+            remain += "-";
+        }
+    }
+
+    // Start a text animation
+    animating = true;
+    cancel_text_animation();
+    cancel_text_animation = Timer::get()->do_every(std::chrono::milliseconds(50), [&]() {
+        display += remain.substr(0, 1);
+        remain = remain.substr(1);
+
+        textbox.set_text(display);
+
+        if (remain.empty()) {
+            animating = false;
+            cancel_text_animation();
+        }
+    });
+}
+
+void DialogUI::skip_animation() {
+    animating = false;
+    cancel_text_animation();
+    textbox.set_text(display + remain);
+}
+
+void DialogUI::stop_display() {
+    // Restore modal input state and disable the UI
+    button_conn.disconnect();
+    input::ModalInput::get()->set_mode(input::ModalInput::NORMAL);
+    disable();
 }

--- a/src/ui/dialog_ui.cpp
+++ b/src/ui/dialog_ui.cpp
@@ -44,8 +44,6 @@ DialogUI::DialogUI(float aspect, float width, float height, float padding)
 }
 
 void DialogUI::display_next() {
-    size_t max = textbox.get_max_chars();
-
     // Reset the text box
     display = "";
 
@@ -68,7 +66,7 @@ void DialogUI::display_next() {
     }
 
     // Chomp the next window-full of text
-    std::tie(current, remaining) = Util::wordbreak_text(remaining, max);
+    std::tie(current, remaining) = Util::wordbreak_text(remaining, textbox.get_max_chars());
 
     // Start a text animation
     animating = true;

--- a/src/ui/dialog_ui.h
+++ b/src/ui/dialog_ui.h
@@ -9,7 +9,6 @@
 // Show a sequence of dialog with events::ui::show_dialog({{portrait_str, text}, ...}).
 class DialogUI : public UI {
 public:
-    // TODO(metakirby5) use this to set portrait and text
     typedef std::pair<std::string, std::string> str_pair;
 
     DialogUI(float aspect, float width, float height, float padding);
@@ -19,13 +18,14 @@ private:
     UIUnstretchedTextBox textbox;
     UIImageNode portrait;
 
-    // Current textbox variables
+    // Variables related to current dialog
     boost::signals2::connection button_conn;
     std::vector<str_pair> current_dialog;
     std::string display, current, remaining;
     bool animating;
     std::function<void()> cancel_text_animation;
 
+    // Helper functions
     void display_next();
     void skip_animation();
     void stop_display();

--- a/src/ui/dialog_ui.h
+++ b/src/ui/dialog_ui.h
@@ -3,12 +3,14 @@
 #include "ui.h"
 #include "ui_unstretched_text_box.h"
 #include "ui_image_node.h"
+#include <boost/signals2.hpp>
 
 // Fully modal, so covers the screen. Should have highest z-index, except for like a pausse menu.
+// Show a sequence of dialog with events::ui::show_dialog({{portrait_str, text}, ...}).
 class DialogUI : public UI {
 public:
     // TODO(metakirby5) use this to set portrait and text
-    typedef std::vector<std::pair<std::string, std::string>> str_pair;
+    typedef std::pair<std::string, std::string> str_pair;
 
     DialogUI(float aspect, float width, float height, float padding);
 
@@ -16,4 +18,15 @@ private:
     UIRectangle bg;
     UIUnstretchedTextBox textbox;
     UIImageNode portrait;
+
+    // Current textbox variables
+    boost::signals2::connection button_conn;
+    std::vector<str_pair> current_dialog;
+    std::string display, remain, overflow;
+    bool animating;
+    std::function<void()> cancel_text_animation;
+
+    void display_next();
+    void skip_animation();
+    void stop_display();
 };

--- a/src/ui/dialog_ui.h
+++ b/src/ui/dialog_ui.h
@@ -22,7 +22,7 @@ private:
     // Current textbox variables
     boost::signals2::connection button_conn;
     std::vector<str_pair> current_dialog;
-    std::string display, remain, overflow;
+    std::string display, current, remaining;
     bool animating;
     std::function<void()> cancel_text_animation;
 

--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -51,6 +51,18 @@ void UIManager::setup_uis() {
 
     /* DIALOG UI (should have high z-index) */
     ui_map["z100-dialog"] = new DialogUI(aspect, 80.f, 30.f, 2.f);
+
+    events::ui::show_dialog(
+            {
+                    {"dio.jpg", "hellotestthisisaprettylongstringihope it will display correctly please help"},
+                    {"slime_blue.png", "this is also some more dialog i am a slime hello i like to hurt people :D"
+                    " i need to make this line really long so it overflows the text box so let me continue to type"
+                    " some more stuff asdfjkl fjsdkl jdgsl sjlsk gjfl it's really hard to come up with good dialogue"
+                    " ughh blah blah blah grandma likes it al dente blah blah sandma blah blah some more things"
+                    " and more and even more henlo"},
+                    {"slime_red.png", "idk what to say anymore so lorem ipsum lorem ipsum etc etc fsdfjsldjdsksdj"},
+            }
+    );
 }
 
 void UIManager::setup_listeners() {

--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -52,17 +52,17 @@ void UIManager::setup_uis() {
     /* DIALOG UI (should have high z-index) */
     ui_map["z100-dialog"] = new DialogUI(aspect, 80.f, 30.f, 2.f);
 
-    events::ui::show_dialog(
-            {
-                    {"dio.jpg", "hellotestthisisaprettylongstringihope it will display correctly please help"},
-                    {"slime_blue.png", "this is also some more dialog i am a slime hello i like to hurt people :D"
-                    " i need to make this line really long so it overflows the text box so let me continue to type"
-                    " some more stuff asdfjkl fjsdkl jdgsl sjlsk gjfl it's really hard to come up with good dialogue"
-                    " ughh blah blah blah grandma likes it al dente blah blah sandma blah blah some more things"
-                    " and more and even more henlo"},
-                    {"slime_red.png", "idk what to say anymore so lorem ipsum lorem ipsum etc etc fsdfjsldjdsksdj"},
-            }
-    );
+//    events::ui::show_dialog(
+//            {
+//                    {"dio.jpg", "hellotestthisisaprettylongstringihope it will display correctly please help"},
+//                    {"slime_blue.png", "this is also some more dialog i am a slime hello i like to hurt people :D"
+//                    " i need to make this line really long so it overflows the text box so let me continue to type"
+//                    " some more stuff asdfjkl fjsdkl jdgsl sjlsk gjfl it's really hard to come up with good dialogue"
+//                    " ughh blah blah blah grandma likes it al dente blah blah sandma blah blah some more things"
+//                    " and more and even more henlo"},
+//                    {"slime_red.png", "idk what to say anymore so lorem ipsum lorem ipsum etc etc fsdfjsldjdsksdj"},
+//            }
+//    );
 }
 
 void UIManager::setup_listeners() {

--- a/src/ui/ui_unstretched_text_box.cpp
+++ b/src/ui/ui_unstretched_text_box.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <util/util.h>
 #include "ui_unstretched_text_box.h"
 
 // Some magic constants for properly spacing the text
@@ -53,7 +54,7 @@ void UIUnstretchedTextBox::set_text(const std::string &text) {
     for (unsigned long i = 0; i < max_lines; ++i) {
         if (remaining.empty()) break;
 
-        std::tie(line, remaining) = break_before(remaining);
+        std::tie(line, remaining) = Util::wordbreak_text(remaining, chars_per_line);
         texts.push_back(
                 std::make_unique<UITextNode>(line, x_off + hpad(line), y_off,
                                              char_width / X_SCALE_FACTOR, char_height / Y_SCALE_FACTOR,
@@ -61,33 +62,6 @@ void UIUnstretchedTextBox::set_text(const std::string &text) {
         attach(*texts.back());
         y_off -= line_height;
     }
-}
-
-std::pair<std::string, std::string> UIUnstretchedTextBox::break_before(std::string text) {
-    // If line is short enough, just chomp all of it
-    if (text.length() <= chars_per_line) {
-        return std::make_pair(text, "");
-    }
-
-    // Find a space to cut at
-    size_t cut_at = text.find_last_of(" ", chars_per_line);
-    std::string line;
-
-    // If we couldn't find a suitable breakpoint, we need to hyphenate
-    if (cut_at == std::string::npos) {
-        return std::make_pair(text.substr(0, chars_per_line - 1) + "-", text.substr(chars_per_line - 1));
-    }
-
-    // Otherwise, cut at the space we found
-    line = text.substr(0, cut_at);
-    text = text.substr(cut_at);
-
-    // Cut out the extra space at the next start of line
-    size_t first_nonspace = text.find_first_not_of(" ");
-    if (first_nonspace != std::string::npos)
-        text = text.substr(first_nonspace);
-
-    return std::make_pair(line, text);
 }
 
 float UIUnstretchedTextBox::calc_pad(Alignment align, float space) {

--- a/src/ui/ui_unstretched_text_box.cpp
+++ b/src/ui/ui_unstretched_text_box.cpp
@@ -15,16 +15,22 @@ UIUnstretchedTextBox::UIUnstretchedTextBox(float char_width, float char_height,
                        float alpha) :
     UIContainer(start_x, start_y),
     char_width(char_width), char_height(char_height),
+    line_height((1 + LINE_SPACE_FACTOR) * char_height),
     width(width), inner_width(width - 2 * padding),
     height(height), inner_height(height - 2 * padding),
     padding(padding),
     chars_per_line(static_cast<unsigned long>(inner_width / char_width)),
-    max_lines(static_cast<int>(height / char_height)),
+    max_lines(static_cast<int>(height / line_height) - 1),
     h_align(h_align), v_align(v_align),
     text_color(text_color),
     bg(0, 0, width, height, bg_color, alpha) {
 
     attach(bg);
+}
+
+unsigned long UIUnstretchedTextBox::get_max_chars() {
+    // For each line, we trim a space, so calculate `chars_per_line * max_lines - max_lines`.
+    return (chars_per_line - 1) * max_lines;
 }
 
 void UIUnstretchedTextBox::set_text(const std::string &text) {
@@ -53,7 +59,7 @@ void UIUnstretchedTextBox::set_text(const std::string &text) {
                                              char_width / X_SCALE_FACTOR, char_height / Y_SCALE_FACTOR,
                                              text_color));
         attach(*texts.back());
-        y_off -= char_height + LINE_SPACE_FACTOR * char_height;
+        y_off -= line_height;
     }
 }
 

--- a/src/ui/ui_unstretched_text_box.h
+++ b/src/ui/ui_unstretched_text_box.h
@@ -22,10 +22,10 @@ public:
                Color text_color, Color bg_color,
                float alpha);
     void set_text(const std::string &text);
-    unsigned long get_max_chars() { return chars_per_line * max_lines; }
+    unsigned long get_max_chars();
 
 private:
-    float char_width, char_height;
+    float char_width, char_height, line_height;
     float width, inner_width, height, inner_height, padding;
     unsigned long chars_per_line;
     int max_lines;

--- a/src/ui/ui_unstretched_text_box.h
+++ b/src/ui/ui_unstretched_text_box.h
@@ -34,9 +34,6 @@ private:
     UIRectangle bg;
     std::vector<std::unique_ptr<UITextNode>> texts;
 
-    // Chomp off as much as we can until a space, but beore EOL
-    std::pair<std::string, std::string> break_before(std::string text);
-
     // Padding calculations
     float calc_pad(Alignment align, float space);
     float hpad(const std::string &line);

--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -117,3 +117,30 @@ bool Util::within_rect(glm::vec2 pos, glm::vec2 bottom_left, glm::vec2 top_right
     }
     return false;
 }
+
+std::pair<std::string, std::string> Util::wordbreak_text(std::string text, unsigned long chars_per_line) {
+    // If line is short enough, just chomp all of it
+    if (text.length() <= chars_per_line) {
+        return std::make_pair(text, "");
+    }
+
+    // Find a space to cut at
+    size_t cut_at = text.find_last_of(" ", chars_per_line);
+    std::string line;
+
+    // If we couldn't find a suitable breakpoint, we need to hyphenate
+    if (cut_at == std::string::npos) {
+        return std::make_pair(text.substr(0, chars_per_line - 1) + "-", text.substr(chars_per_line - 1));
+    }
+
+    // Otherwise, cut at the space we found
+    line = text.substr(0, cut_at);
+    text = text.substr(cut_at);
+
+    // Cut out the extra space at the next start of line
+    size_t first_nonspace = text.find_first_not_of(" ");
+    if (first_nonspace != std::string::npos)
+        text = text.substr(first_nonspace);
+
+    return std::make_pair(line, text);
+};

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -30,4 +30,8 @@ public:
     static float random(float min, float max);
 
     static bool within_rect(glm::vec2 pos, glm::vec2 bottom_left, glm::vec2 top_right);
+
+    // Chomp off as much as we can until a space, but beore EOL
+    // Returns (line, remaining text)
+    static std::pair<std::string, std::string> wordbreak_text(std::string text, unsigned long chars_per_line);
 };

--- a/vs/vs.vcxproj
+++ b/vs/vs.vcxproj
@@ -247,6 +247,11 @@ xcopy /F /Y "$(SolutionDir)\packages\boost_signals-vc140.1.64.0.0\lib\native\add
     <ClInclude Include="..\src\ui\legend_ui.h" />
     <ClInclude Include="..\src\ui\render2d.h" />
     <ClInclude Include="..\src\ui\ui.h" />
+    <ClInclude Include="..\src\ui\gold_ui.h" />
+    <ClInclude Include="..\src\ui\leaderboard_ui.h" />
+    <ClInclude Include="..\src\ui\legend_ui.h" />
+    <ClInclude Include="..\src\ui\render2d.h" />
+    <ClInclude Include="..\src\ui\ui.h" />
     <ClInclude Include="..\src\ui\ui_container.h" />
     <ClInclude Include="..\src\ui\ui_element.h" />
     <ClInclude Include="..\src\ui\ui_grid.h" />
@@ -350,6 +355,11 @@ xcopy /F /Y "$(SolutionDir)\packages\boost_signals-vc140.1.64.0.0\lib\native\add
     <ClCompile Include="..\src\ui\clock_ui.cpp" />
     <ClCompile Include="..\src\ui\debug_ui.cpp" />
     <ClCompile Include="..\src\ui\dialog_ui.cpp" />
+    <ClCompile Include="..\src\ui\gold_ui.cpp" />
+    <ClCompile Include="..\src\ui\leaderboard_ui.cpp" />
+    <ClCompile Include="..\src\ui\legend_ui.cpp" />
+    <ClCompile Include="..\src\ui\render2d.cpp" />
+    <ClCompile Include="..\src\ui\ui.cpp" />
     <ClCompile Include="..\src\ui\gold_ui.cpp" />
     <ClCompile Include="..\src\ui\leaderboard_ui.cpp" />
     <ClCompile Include="..\src\ui\legend_ui.cpp" />


### PR DESCRIPTION
![](https://ptpb.pw/e4jM.gif)

Above gif shows two things:
- Going through a dialogue sequence without skipping any text
- Going through a dialogue sequence skipping through as fast as possible

Text is animated. Button presses skip animation if currently animating;
otherwise, they proceed to the next box of text. API is very simple:
Simply dispatch a `events::ui::show_dialog` with `{{portrait, dialogue}, ...}`.
Text which overfills a dialogue box worth of text will automatically be paginated.

Example:
```c++
events::ui::show_dialog(
        {
                {"dio.jpg", "hellotestthisisaprettylongstringihope it will display correctly please help"},
                {"slime_blue.png", "this is also some more dialog i am a slime hello i like to hurt people :D"
                " i need to make this line really long so it overflows the text box so let me continue to type"
                " some more stuff asdfjkl fjsdkl jdgsl sjlsk gjfl it's really hard to come up with good dialogue"
                " ughh blah blah blah grandma likes it al dente blah blah sandma blah blah some more things"
                " and more and even more henlo"},
                {"slime_red.png", "idk what to say anymore so lorem ipsum lorem ipsum etc etc fsdfjsldjdsksdj"},
        }
);
```