### PR TITLE
Fixed rotation bug

### DIFF
--- a/src/components/transform.h
+++ b/src/components/transform.h
@@ -30,7 +30,6 @@ public:
 
     glm::mat4 get_world_mat();
     glm::vec3 get_position();
-    glm::vec3 get_rotation();
     glm::vec3 get_scale();
 
     glm::vec3 get_forward();

--- a/src/game_objects/traps/projectile.cpp
+++ b/src/game_objects/traps/projectile.cpp
@@ -18,7 +18,7 @@ void Projectile::fire(Transform spawn_location) {
     // Spawn object in front of trap
     glm::vec3 offset = ((spawn_location.get_forward() * 0.5f) + (spawn_location.get_up() * height_offset));
     set_position(spawn_location.get_position() + offset);
-    transform.set_rotation(spawn_location.get_rotation());
+    transform.look_at(spawn_location.get_forward());
 
     setup_timer(); // Set-up Time-Out. 
 


### PR DESCRIPTION
Got rid of getting euler angles for rotations cause it was buggy. Instead, just use the rotation matrix if need to get the rotation. Also, use look_at if you want to rotate the matrix in a certain direction. 