### PR TITLE
Add client player to context for ease

### DIFF
--- a/src/game/context.h
+++ b/src/game/context.h
@@ -13,6 +13,7 @@ public:
     std::unordered_map<int, bool> ready_flags; // <Player id, if ready>
 
     // Client
+    Player* client_player;
     int player_id;
     bool player_finished;
 };

--- a/src/game/game_state.cpp
+++ b/src/game/game_state.cpp
@@ -154,14 +154,16 @@ Player* GameState::s_add_player(int conn_id) {
 }
 
 Player* GameState::c_add_player(int obj_id, int model_index, bool is_client) {
-    if (is_client)
-        context.player_id = obj_id;
-
     Player *player = new Player(obj_id);
     player->c_setup_player_model(model_index);
     
     start_scene.objs.push_back(player);
     main_scene.objs.push_back(player);
+
+    if (is_client) {
+        context.player_id = obj_id;
+        context.client_player = player;
+    }
 
     return player;
 }


### PR DESCRIPTION
Makes it easier to access the client Player* when you're in a GameObject.