### PR TITLE
Made Color value conversion optional

### DIFF
--- a/src/asset_loader.cpp
+++ b/src/asset_loader.cpp
@@ -186,8 +186,8 @@ Mesh *AssetLoader::process_mesh(aiMesh *mesh, const aiScene *scene) {
     assimpMat->Get(AI_MATKEY_COLOR_SPECULAR, specular);
     float shiny = 0.0f;
     assimpMat->Get(AI_MATKEY_SHININESS, shiny);
-    load_mat->diffuse = Color(diffuse.r, diffuse.g, diffuse.b);
-    load_mat->specular = Color(specular.r, specular.g, specular.b);
+    load_mat->diffuse = Color(diffuse.r, diffuse.g, diffuse.b, false);
+    load_mat->specular = Color(specular.r, specular.g, specular.b, false);
     load_mat->shininess = shiny;
     final_mesh = new Mesh(geo, load_mat);
 

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -53,3 +53,32 @@ void Model::set_shadows(bool enable) {
         mesh->material->shadows = enable;
     }
 }
+
+void Model::save_colors() {
+    original_colors.clear();
+    for (Mesh *mesh : meshes) {
+        original_colors.push_back(mesh->material->diffuse);
+    }
+}
+
+void Model::reset_colors() {
+    if (original_colors.size() != meshes.size())
+        return; // Cannot reset color
+
+    // Reset using original colors
+    for (int i = 0; i < original_colors.size(); i++) {
+        meshes[i]->material->diffuse = original_colors[i];
+    }
+}
+
+void Model::add_colors(Color color) {
+    for (Mesh *mesh : meshes) {
+        mesh->material->diffuse.add(color);
+    }
+}
+
+void Model::multiply_colors(Color color) {
+    for (Mesh *mesh : meshes) {
+        mesh->material->diffuse.multiply(color);
+    }
+}

--- a/src/model/model.h
+++ b/src/model/model.h
@@ -16,6 +16,7 @@
 class Model {
 private:
     Shader *model_shader;
+    std::vector<Color> original_colors;
 public:
     std::vector<Mesh *> meshes;
     Skeleton initial_skeleton; // Initial skeleton that model is compatible with, not updated.
@@ -31,10 +32,13 @@ public:
     void set_model_filter(ModelFilter &filter);
 
     void set_color(Color color);
-
     void set_alpha(float alpha);
-
     void set_shadows(bool enable);
+
+    void save_colors(); // Save original colors of the model
+    void reset_colors(); // Reset to original colors
+    void add_colors(Color color);
+    void multiply_colors(Color color);
 
     void set_shader(Shader *shader) { model_shader = shader; }
 };

--- a/src/util/color.cpp
+++ b/src/util/color.cpp
@@ -1,13 +1,13 @@
 #include "color.h"
 
-Color Color::WHITE              (1.f, 1.f, 1.f);
-Color Color::BLACK              (0.f, 0.f, 0.f);
-Color Color::RED                (1.f, 0.f, 0.f);
-Color Color::GREEN              (0.f, 1.f, 0.f);
-Color Color::BLUE               (0.f, 0.f, 1.f);
-Color Color::CYAN               (0.f, 1.f, 1.f);
-Color Color::YELLOW             (1.f, 1.f, 0.f);
-Color Color::MAGENTA            (1.f, 0.f, 1.f);
+Color Color::WHITE              (1.f, 1.f, 1.f, false);
+Color Color::BLACK              (0.f, 0.f, 0.f, false);
+Color Color::RED                (1.f, 0.f, 0.f, false);
+Color Color::GREEN              (0.f, 1.f, 0.f, false);
+Color Color::BLUE               (0.f, 0.f, 1.f, false);
+Color Color::CYAN               (0.f, 1.f, 1.f, false);
+Color Color::YELLOW             (1.f, 1.f, 0.f, false);
+Color Color::MAGENTA            (1.f, 0.f, 1.f, false);
 
 Color Color::OCEAN_BLUE         (80, 186, 244);
 Color Color::WINDWAKER_GREEN    (156, 217, 84);
@@ -33,26 +33,20 @@ Color Color::GOLD               (255, 215, 10);
 Color Color::SILVER             (192, 192, 192);
 Color Color::BRONZE             (205, 127, 50);
 
-Color::Color(float red, float green, float blue) {
+Color::Color(float red, float green, float blue, bool convert_down) {
     r = red;
     g = green;
     b = blue;
-    if (r > 1.f || g > 1.f || b > 1.f) { // RGB format where values out of 255
+
+    if (convert_down) { // RGB format where values out of 255
         r /= 255.f;
         g /= 255.f;
         b /= 255.f;
     }
 }
 
-Color::Color(glm::vec3 v) {
-    r = v.x;
-    g = v.y;
-    b = v.z;
-    if (r > 1.f || g > 1.f || b > 1.f) { // RGB format where values out of 255
-        r /= 255.f;
-        g /= 255.f;
-        b /= 255.f;
-    }
+Color::Color(glm::vec3 v, bool convert_down) {
+    Color(v.x, v.y, v.z, convert_down);
 }
 
 void Color::set(float red, float green, float blue) {

--- a/src/util/color.h
+++ b/src/util/color.h
@@ -6,8 +6,8 @@ class Color {
 private:
     float r, g, b; // red green blue color values (vary from 0.f - 1.f)
 public:
-    Color(float red = 1.f, float green = 1.f, float blue = 1.f); // Default color is white (1.f, 1.f, 1.f)
-    Color(glm::vec3 v);
+    Color(float red = 255.f, float green = 255.f, float blue = 255.f, bool convert_down = true); // Default color is white (1.f, 1.f, 1.f)
+    Color(glm::vec3 v, bool convert_down = true);
     void set(float red, float green, float blue); // set this color
     void set(glm::vec3 v);
     void add(const Color other); // add another color


### PR DESCRIPTION
Added a boolean for converting from 0-255 range to 0-1.0f range for Colors, making it easier to work with for future color overlay effects that is used in "slow_traps" branch. 

Also added functions on Model that makes it easier to multiply colors to the model, and then revert back to original colors. 