### PR TITLE
Add gold deltas and UIUnstretchedTextBos::set_color

### DIFF
--- a/src/ui/gold_ui.cpp
+++ b/src/ui/gold_ui.cpp
@@ -10,25 +10,31 @@
 GoldUI::GoldUI(float aspect)
         : UI(90.f * aspect, 0.f),
           bg(0, 0, 10.f * aspect, 7.f * aspect, Color::BLACK, 0.5f),
-          gold_delta("+0g",
-                     2.5f * aspect, 10.f, // starting coordinates
-                     5.f * aspect, 5.f, // width and height
-                     Color::WHITE),
+          gold_delta(3.f, 4.f,
+                     0, 0, 10.f * aspect, 8.f * aspect, // Same-ish size as BG for convenience
+                     0.f, UIUnstretchedTextBox::MIDDLE, UIUnstretchedTextBox::START,
+                     Color::WHITE, Color::BLACK, 0.f, false),
           gold_image(2.5f * aspect, -1.f,
                      5.f * aspect, 5.f * aspect,
                      AssetLoader::get_texture("essence.png")),
-          total_gold("100",
+          total_gold("-",
                      2.5f * aspect, 4.f * aspect,
                      5.f * aspect, 5.f,
-                     Color::WHITE) {
+                     Color::WHITE),
+          cur_gold(0),
+          cur_delta(0),
+          delta_showing(false),
+          cancel_delta_out([](){}) {
 
     attach(bg);
 
-    attach(gold_delta);
-    gold_delta.disable(); // not shown by default
-
     attach(total_gold);
     attach(gold_image);
+
+    // Hide at first
+    gold_delta.set_alpha(0.f);
+    attach(gold_delta);
+    set_gold(100); // TODO(metakirby5/jytang): don't hardcode heh
 
     events::c_player_stats_updated.connect([&](const proto::PlayerStats &update) {
         set_gold(update.coins());
@@ -36,5 +42,43 @@ GoldUI::GoldUI(float aspect)
 }
 
 void GoldUI::set_gold(int gold) {
-    total_gold.set_text(std::to_string(gold));
+    // If delta not showing, animate it in and prepare to animate it out
+    if (!delta_showing) {
+        delta_showing = true;
+        cur_delta = 0;
+        gold_delta.animate_alpha(1.f, .25f);
+        gold_delta.animate_relative(0, 2.f, .25f, [this]() {
+            fade_delta_after(500);
+        });
+    } else {
+        fade_delta_after(500);
+    }
+
+    // Update amounts
+    cur_delta += gold - cur_gold;
+    cur_gold = gold;
+    total_gold.set_text(std::to_string(cur_gold));
+
+    // Update delta text
+    std::string prefix = cur_delta < 0 ? "-" : "+";
+    Color color = cur_delta < 0 ? Color::INDIAN_RED : Color::WINDWAKER_GREEN;
+    gold_delta.set_text(prefix + std::to_string(std::abs(cur_delta)));
+    gold_delta.set_color(color);
+}
+
+void GoldUI::fade_delta_after(int ms) {
+    // Cancel any existing fade state
+    cancel_delta_out();
+
+    // To cancel the existing animation, if any
+    gold_delta.animate_alpha(1.f, .01f, [this]() {
+        cancel_delta_out = Timer::get()->do_after(std::chrono::milliseconds(500), [this]() {
+            gold_delta.animate_alpha(0.f, .1f, [this]() {
+                // Reset the delta
+                delta_showing = false;
+                gold_delta.set_start_x(0);
+                gold_delta.set_start_y(0);
+            });
+        });
+    });
 }

--- a/src/ui/gold_ui.h
+++ b/src/ui/gold_ui.h
@@ -3,15 +3,23 @@
 #include "ui.h"
 #include "ui_text_box.h"
 #include "ui_image_node.h"
+#include "ui_unstretched_text_box.h"
 
+// Deltas support up to 4 digits.
 class GoldUI : public UI {
 public:
     GoldUI(float aspect);
 private:
+    int cur_gold;
+    int cur_delta;
+    bool delta_showing;
+    std::function<void()> cancel_delta_out;
+
     void set_gold(int gold);
+    void fade_delta_after(int ms);
 
     UIRectangle bg;
-    UITextBox gold_delta;
+    UIUnstretchedTextBox gold_delta;
     UITextBox total_gold;
     UIImageNode gold_image;
 };

--- a/src/ui/ui_unstretched_text_box.cpp
+++ b/src/ui/ui_unstretched_text_box.cpp
@@ -13,7 +13,7 @@ UIUnstretchedTextBox::UIUnstretchedTextBox(float char_width, float char_height,
                        float width, float height, float padding,
                        Alignment h_align, Alignment v_align,
                        Color text_color, Color bg_color,
-                       float alpha) :
+                       float alpha, bool draw_bg) :
     UIContainer(start_x, start_y),
     char_width(char_width), char_height(char_height),
     line_height((1 + LINE_SPACE_FACTOR) * char_height),
@@ -26,7 +26,8 @@ UIUnstretchedTextBox::UIUnstretchedTextBox(float char_width, float char_height,
     text_color(text_color),
     bg(0, 0, width, height, bg_color, alpha) {
 
-    attach(bg);
+    if (draw_bg)
+        attach(bg);
 }
 
 unsigned long UIUnstretchedTextBox::get_max_chars() {
@@ -86,4 +87,10 @@ void UIUnstretchedTextBox::set_alpha(float alpha) {
     float restore_bg_alpha = bg.get_alpha();
     UIContainer::set_alpha(alpha);
     bg.set_alpha(restore_bg_alpha);
+}
+
+void UIUnstretchedTextBox::set_color(Color color) {
+    text_color = color;
+    for (auto &text : texts)
+        text->set_color(color);
 }

--- a/src/ui/ui_unstretched_text_box.h
+++ b/src/ui/ui_unstretched_text_box.h
@@ -20,8 +20,9 @@ public:
                float padding,
                Alignment h_align, Alignment v_align,
                Color text_color, Color bg_color,
-               float alpha);
+               float alpha, bool draw_bg = true);
     void set_text(const std::string &text);
+    void set_color(Color color);
     unsigned long get_max_chars();
     void set_alpha(float alpha) override;
 


### PR DESCRIPTION
Add deltas with +/- text over the gold UI when the gold changes.
The delta fades in and translates upwards for animation, sticks on-screen
for 0.5s, and then quickly fades out. If the delta is still showing while
there are further gold changes, the delta rolls over and accumulates, resetting
the fade out timer. This is to reduce screen clutter and confusion.

Gold deltas are colorized as follows:
  - Negative delta = `Color::INDIAN_RED`
  - Positive delta = `Color::WINDWAKER_GREEN`