### PR TITLE
Added event to stop all sound effects after (dungeon) phase.

### DIFF
--- a/src/audio/audio_manager.cpp
+++ b/src/audio/audio_manager.cpp
@@ -65,17 +65,19 @@ AudioManager::AudioManager() : muted(true), max_music_volume(100.0), max_sound_e
         active_sounds[inactive_sound_index].setBuffer(sound_buffers[filename]);
         active_sounds[inactive_sound_index].setVolume(vol);
 
-        // Need to think of better way to do looped sound effects if necessary
-        //sounds[filename].setLoop(d.loop);
-
-        //if (d.loop) {
-        //    sounds[filename].play();
-        //    sounds[filename].pause();
-        //}
+        // Need to think of better way to stop looped sound effects if necessary
+        active_sounds[inactive_sound_index].setLoop(d.loop);
 
         if (muted) return;
 
         active_sounds[inactive_sound_index].play();
+    });
+
+    events::stop_all_sounds.connect([&]() {
+        for (int i = 0; i < active_sounds.size(); i++) {
+            active_sounds[i] = sf::Sound();
+        }
+        std::cerr << "Done stopping sounds" << std::endl;
     });
 
     events::toggle_mute_event.connect([&]() {
@@ -88,7 +90,9 @@ AudioManager::AudioManager() : muted(true), max_music_volume(100.0), max_sound_e
                 sound.pause();
             }
         } else {
-            music.play();
+            if (music.getStatus() == sf::Music::Status::Paused) {
+                music.play();
+            }
 
             // Play sound effects that has been paused
             for (sf::Sound sound : active_sounds) {

--- a/src/audio/audio_manager.cpp
+++ b/src/audio/audio_manager.cpp
@@ -77,7 +77,6 @@ AudioManager::AudioManager() : muted(true), max_music_volume(100.0), max_sound_e
         for (int i = 0; i < active_sounds.size(); i++) {
             active_sounds[i] = sf::Sound();
         }
-        std::cerr << "Done stopping sounds" << std::endl;
     });
 
     events::toggle_mute_event.connect([&]() {

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -7,6 +7,7 @@ namespace events {
     signal<void(const StickData &)> stick_event;
     signal<void(const AudioData &)> music_event;
     signal<void(const AudioData &)> sound_effects_event;
+    signal<void()> stop_all_sounds;
     signal<void()> toggle_mute_event;
     signal<void(WindowSizeData &)> window_buffer_resize_event;
     signal<void(WindowKeyData &)> window_key_event;

--- a/src/events.h
+++ b/src/events.h
@@ -78,6 +78,7 @@ namespace events {
     };
     extern signal<void(const AudioData &)> music_event;
     extern signal<void(const AudioData &)> sound_effects_event;
+    extern signal<void()> stop_all_sounds;
     extern signal<void()> toggle_mute_event;
 
     struct WindowSizeData {

--- a/src/game/phase/dungeon.cpp
+++ b/src/game/phase/dungeon.cpp
@@ -159,4 +159,6 @@ void DungeonPhase::c_teardown() {
     button_conn.disconnect();
     essence_conn.disconnect();
     player_finish_conn.disconnect();
+
+    events::stop_all_sounds();
 }


### PR DESCRIPTION
This feature clears up our active sounds after the dungeon phase (we can extend it to other phases if needed).
Use case: the portal buzz sound (used to indicate to the player that the portal is close) will be looped and the sound should stop after the dungeon phase finishes.
We can probably come up with something sophisticated to stop specific looping sounds but we don't have a use case for it now that we don't have footstep sounds. Also, clearing our active sounds is a good idea nonetheless.
I tested it by making the arrow trap sound loop and see whether it'll stop when I transition into build phase again.

Also added if statement to toggle mute because when we try to unmute before the first build phase, no music is being played and therefore an error message is thrown.