### PR TITLE
Fixed Bullet Debug Drawer

### DIFF
--- a/src/aldente_client.cpp
+++ b/src/aldente_client.cpp
@@ -21,7 +21,6 @@
 #include "net/network_manager.h"
 #include "shaders/shader_manager.h"
 #include "audio/audio_manager.h"
-#include "bt_debug.h"
 
 AldenteClient::~AldenteClient() {
     GeometryGenerator::destroy();
@@ -98,9 +97,6 @@ void AldenteClient::start() {
 
     Render render(window, GameState::scene_manager);
 
-    // Debug Drawer for Bullet
-    btDebug bt_debug(&GameState::physics);
-
     DebugInput debug_input(window, GameState::scene_manager, GameState::physics);
 
     // Have window fire off a resize event to update all interested systems.
@@ -131,7 +127,6 @@ void AldenteClient::start() {
         GameState::c_update();
 
         render.update();
-        bt_debug.draw(GameState::scene_manager.get_current_scene()->info);
         ui_manager.draw();
         window.swap_buffers();
     }

--- a/src/bt_debug.cpp
+++ b/src/bt_debug.cpp
@@ -1,11 +1,12 @@
 #include "bt_debug.h"
 #include "GL/glew.h"
-#include <iostream>
 #include "shaders/shader_manager.h"
-#include "scene_manager.h"
+#include "game/game_state.h"
 #include "events.h"
 
-btDebug::btDebug(Physics *physics) : physics(physics) {
+#include <iostream>
+
+btDebug::btDebug() {
     setDebugMode(btIDebugDraw::DBG_DrawWireframe);
 
     lines = new Mesh();
@@ -33,9 +34,12 @@ void btDebug::clear() {
     geo->indices.clear();
 }
 
-void btDebug::draw(SceneInfo &scene_info) {
+void btDebug::draw() {
     if (!enabled)
         return;
+
+    Physics *physics = &GameState::physics;
+    SceneInfo scene_info = GameState::scene_manager.get_current_scene()->info;
 
     if (physics->dynamicsWorld == NULL)
         return;
@@ -46,6 +50,7 @@ void btDebug::draw(SceneInfo &scene_info) {
     clear();
 
     // Calls "drawLine" for all box colliders registered in the world
+    // Note: This requires the rigid bodies to exist on client
     physics->dynamicsWorld->debugDrawWorld();
 
     for (int i = 0; i < geo->vertices.size(); i++)
@@ -59,7 +64,6 @@ void btDebug::draw(SceneInfo &scene_info) {
 }
 
 void btDebug::drawLine(const btVector3& from, const btVector3& to, const btVector3& color) {
-
     geo->vertices.push_back({ from.getX(), from.getY(), from.getZ() });
     geo->vertices.push_back({ to.getX(), to.getY(), to.getZ() });
     geo->normals.push_back({ 1, 1, 1 });

--- a/src/bt_debug.h
+++ b/src/bt_debug.h
@@ -11,10 +11,10 @@
 class btDebug : public btIDebugDraw {
 public:
 
-    btDebug(Physics *physics);
+    btDebug();
 
     void clear(); // Clears buffers
-    void draw(SceneInfo &scene_info);
+    void draw();
     void set_enable(bool b);
 
     /* Virtual functions from Bullet's Interface*/
@@ -29,8 +29,6 @@ private:
     bool enabled = false;
 
     int debug_mode;
-
-    Physics *physics;
 
     Material *mat;
     Geometry *geo;

--- a/src/render/render.cpp
+++ b/src/render/render.cpp
@@ -1,7 +1,9 @@
 #include "render.h"
 
 Render::Render(Window &window, SceneManager &scene_manager)
-    : window(window), scene_manager(scene_manager) {}
+    : window(window), scene_manager(scene_manager) {
+    bt_debug = new btDebug();
+}
 
 // Render pipeline
 // Alternatively can acquire current scene via some ChangeScene event
@@ -18,6 +20,9 @@ void Render::update() {
 
     curr_scene->draw_skybox(); // Skybox rendered last for optimization
     curr_scene->draw();
+
+    // Draws rigidbody in physics world
+    bt_debug->draw();
 
     // Apply HDR. Render as a quad.
     hdr.render(curr_scene);

--- a/src/render/render.h
+++ b/src/render/render.h
@@ -4,6 +4,7 @@
 #include "window.h"
 #include "scene_manager.h"
 #include "render/hdr.h"
+#include "bt_debug.h"
 
 class Render {
 private:
@@ -14,6 +15,8 @@ private:
     Window &window;
 
     SceneManager &scene_manager;
+
+    btDebug *bt_debug;
 
 public:
     Render(Window &window, SceneManager &scene_manager);


### PR DESCRIPTION
Apparently the HDR draw call did something to cause the bullet debug drawer to not work, so I just moved the debug drawer within Render.cpp before the HDR call. 

To use, you must still add the rigidbody on the client side. (Basically, move the "add_rigidbody_event" to outside the if(id==ON_SERVER) loop)