### PR TITLE
Out of bounds check

### DIFF
--- a/src/net/network_manager.cpp
+++ b/src/net/network_manager.cpp
@@ -358,7 +358,7 @@ void ClientNetworkManager::update() {
                     }
                 }
 
-                if (obj_exists)
+                if (obj_exists && GameObject::game_objects.find(obj.id()) != GameObject::game_objects.end())
                     GameObject::game_objects[obj.id()]->c_update_state(world_mat, obj.enabled());
             }
 


### PR DESCRIPTION
Hot fix for checking if the object id is out of bounds.

Problem caused by server and client not always being on the same phase during transitions.