### PR TITLE
Unready + UI ready indicator in build phase

### DIFF
--- a/src/events.cpp
+++ b/src/events.cpp
@@ -97,6 +97,7 @@ namespace events {
         signal<void(int,int)> hover_position_updated_event;
         signal<void()> start_build_event;
         signal<void()> end_build_event;
+        signal<void()> toggle_ui_ready_event;
     }
 
     namespace dungeon {

--- a/src/events.h
+++ b/src/events.h
@@ -279,6 +279,9 @@ namespace events {
 
         // Signals that the build phase has ended
         extern signal<void()> end_build_event;
+
+        // Updates the UI to indicate that the user has readied (or unreadied) up.
+        extern signal<void()> toggle_ui_ready_event;
     }
 
     namespace dungeon {

--- a/src/game/phase/build.cpp
+++ b/src/game/phase/build.cpp
@@ -110,10 +110,11 @@ void BuildPhase::c_setup() {
                 break;
             }
             case events::BTN_START: {
+                events::build::toggle_ui_ready_event();
+
                 proto::ClientMessage msg;
                 msg.set_ready_request(context.player_id);
                 events::client::send(msg);
-                events::build::toggle_ui_ready_event();
                 break;
             }
             case events::BTN_UP: {

--- a/src/game/phase/build.cpp
+++ b/src/game/phase/build.cpp
@@ -113,6 +113,7 @@ void BuildPhase::c_setup() {
                 proto::ClientMessage msg;
                 msg.set_ready_request(context.player_id);
                 events::client::send(msg);
+                events::build::toggle_ui_ready_event();
                 break;
             }
             case events::BTN_UP: {

--- a/src/game/phase/build.cpp
+++ b/src/game/phase/build.cpp
@@ -10,7 +10,8 @@ void BuildPhase::s_setup() {
 
     transition_after(60, proto::Phase::DUNGEON);
     ready_conn = events::player_ready_event.connect([&](int player_id) {
-        context.ready_flags[player_id] = true;
+        // Ready up if not previously ready. Otherwise un-ready up.
+        context.ready_flags[player_id] = !context.ready_flags[player_id];
     });
 
     s_verify_and_build_conn = events::build::s_verify_and_build.connect([&](proto::Construct& c) {

--- a/src/game/phase/menu.cpp
+++ b/src/game/phase/menu.cpp
@@ -4,7 +4,8 @@
 
 void MenuPhase::s_setup() {
     ready_conn = events::player_ready_event.connect([&](int player_id) {
-        context.ready_flags[player_id] = true;
+        // Ready up if not previously ready. Otherwise un-ready up.
+        context.ready_flags[player_id] = !context.ready_flags[player_id];
     });
 }
 

--- a/src/ui/clock_ui.cpp
+++ b/src/ui/clock_ui.cpp
@@ -17,7 +17,10 @@ ClockUI::ClockUI(float aspect, int rounds)
                 (20.f * aspect - (rounds + 1) * 0.2f) / rounds, 2.f, // width and height
                 Color::BLACK, // background color
                 0.2f, // padding
-                0) { // no halo selector
+                0),  // no halo selector
+          ready(5.f, 5.f, 0.f, -20.f, 20.f * aspect, 10.f, 0.f,
+                UIUnstretchedTextBox::MIDDLE, UIUnstretchedTextBox::MIDDLE,
+                Color::BLACK, Color::BLACK, 1.f, false) {
 
     attach(clock);
 
@@ -35,6 +38,10 @@ ClockUI::ClockUI(float aspect, int rounds)
     }
 
     attach(round_count_bg);
+
+    ready.set_text("READY!");
+    attach(ready);
+
     disable();
 
     events::menu::end_menu_event.connect([&]() {

--- a/src/ui/clock_ui.cpp
+++ b/src/ui/clock_ui.cpp
@@ -64,8 +64,13 @@ ClockUI::ClockUI(float aspect, int rounds)
         ready.set_text("");
     });
 
+    events::build::end_build_event.connect([&]() {
+        player_ready = false;
+        ready.set_text("");
+    });
+
     events::build::toggle_ui_ready_event.connect([&]() {
-        player_ready != player_ready;
+        player_ready = !player_ready;
         if (player_ready)
             ready.set_text("READY!");
         else

--- a/src/ui/clock_ui.cpp
+++ b/src/ui/clock_ui.cpp
@@ -18,8 +18,8 @@ ClockUI::ClockUI(float aspect, int rounds)
                 Color::BLACK, // background color
                 0.2f, // padding
                 0),  // no halo selector
-          ready(3.f, 3.f, 0.f, -14.f, 20.f * aspect, 10.f, 0.f,
-                UIUnstretchedTextBox::MIDDLE, UIUnstretchedTextBox::MIDDLE,
+          ready(3.f, 3.f, 0.f, -24.f, 20.f * aspect, 20.f, 0.f,
+                UIUnstretchedTextBox::MIDDLE, UIUnstretchedTextBox::START,
                 Color::BLACK, Color::BLACK, 1.f, false) {
 
     attach(clock);
@@ -61,7 +61,7 @@ ClockUI::ClockUI(float aspect, int rounds)
 
     events::build::start_build_event.connect([&]() {
         player_ready = false;
-        ready.set_text("");
+        ready.set_text("PRESS START WHEN READY");
     });
 
     events::build::end_build_event.connect([&]() {
@@ -74,7 +74,7 @@ ClockUI::ClockUI(float aspect, int rounds)
         if (player_ready)
             ready.set_text("READY!");
         else
-            ready.set_text("");
+            ready.set_text("PRESS START WHEN READY");
     });
 }
 

--- a/src/ui/clock_ui.cpp
+++ b/src/ui/clock_ui.cpp
@@ -18,7 +18,7 @@ ClockUI::ClockUI(float aspect, int rounds)
                 Color::BLACK, // background color
                 0.2f, // padding
                 0),  // no halo selector
-          ready(5.f, 5.f, 0.f, -20.f, 20.f * aspect, 10.f, 0.f,
+          ready(3.f, 3.f, 0.f, -14.f, 20.f * aspect, 10.f, 0.f,
                 UIUnstretchedTextBox::MIDDLE, UIUnstretchedTextBox::MIDDLE,
                 Color::BLACK, Color::BLACK, 1.f, false) {
 
@@ -39,7 +39,8 @@ ClockUI::ClockUI(float aspect, int rounds)
 
     attach(round_count_bg);
 
-    ready.set_text("READY!");
+    player_ready = false;
+    ready.set_text("");
     attach(ready);
 
     disable();
@@ -56,6 +57,19 @@ ClockUI::ClockUI(float aspect, int rounds)
         // If we go past the max number of rounds, no change to UI.
         if (next_round <= round_counts.size())
             round_counts[next_round - 1]->set_alpha(0.8f);
+    });
+
+    events::build::start_build_event.connect([&]() {
+        player_ready = false;
+        ready.set_text("");
+    });
+
+    events::build::toggle_ui_ready_event.connect([&]() {
+        player_ready != player_ready;
+        if (player_ready)
+            ready.set_text("READY!");
+        else
+            ready.set_text("");
     });
 }
 

--- a/src/ui/clock_ui.h
+++ b/src/ui/clock_ui.h
@@ -19,4 +19,5 @@ private:
     UIUnstretchedTextBox ready;
 
     std::vector<UIRectangle*> round_counts;
+    bool player_ready;
 };

--- a/src/ui/clock_ui.h
+++ b/src/ui/clock_ui.h
@@ -4,6 +4,7 @@
 #include "ui_text_box.h"
 #include "ui_grid.h"
 #include "ui_rectangle.h"
+#include "ui_unstretched_text_box.h"
 
 class ClockUI : public UI {
 public:
@@ -15,5 +16,7 @@ private:
 
     UITextBox clock;
     UIGrid round_count_bg;
+    UIUnstretchedTextBox ready;
+
     std::vector<UIRectangle*> round_counts;
 };


### PR DESCRIPTION
* Pressing the start button no longer sets ready to `true` but just toggles the ready status
* Add a "READY!" text box to build phase to indicate if the current player is ready

![ready](http://puu.sh/webxB/85a5a19692.jpg)