### PR TITLE
Cleanup Leftover Objects

### DIFF
--- a/src/game_objects/construct.cpp
+++ b/src/game_objects/construct.cpp
@@ -13,7 +13,8 @@ Construct::Construct(int x, int z, int id) : GameObject(id) {
 
 /************CHEST***************/
 
-Chest::Chest(int x, int z, int id) : Construct(x, z, id) {
+Chest::Chest(int x, int z, int id) : Construct(x, z, id),
+        cancel_disappear([]() {}), cancel_fade([]() {}) {
     tag = "CHEST";
 
     events::dungeon::s_prepare_dungeon_event.connect([&]() {
@@ -92,17 +93,14 @@ void Chest::disappear() {
 }
 
 void Chest::s_reset() {
-    if (cancel_disappear)
-        cancel_disappear();
+    cancel_disappear();
     opened = false;
     enable();
 }
 
 void Chest::c_reset() {
-    if (cancel_disappear)
-        cancel_disappear();
-    if(cancel_fade)
-        cancel_fade();
+    cancel_disappear();
+    cancel_fade();
     anim_player.stop();
     set_filter_alpha(1.0f);
     enable();

--- a/src/game_objects/essence.cpp
+++ b/src/game_objects/essence.cpp
@@ -14,7 +14,8 @@
 #define ESSENCE_TIME_OUT 6000 // Milliseconds
 #define DISAPPEAR_ANIM_LENGTH 500 // Time it takes for disappearing animation to finish
 
-Essence::Essence(int id) : GameObject(id){
+Essence::Essence(int id) : GameObject(id), cancel_fade([]() {}),
+    cancel_timeout([]() {}), cancel_rainbow([]() {}) {
     tag = "ESSENCE";
 
     // Set Value
@@ -175,21 +176,12 @@ void Essence::disable_after_disappear() {
 // Disables everything on object
 void Essence::s_reset() {
     disable();
-    if (cancel_fade)
-        cancel_fade();
-    if (cancel_rainbow)
-        cancel_rainbow();
-    if (cancel_timeout)
-        cancel_timeout();
+    cancel_fade();
+    cancel_rainbow();
+    cancel_timeout();
 }
 
 // Disables everything on object
 void Essence::c_reset() {
-    disable();
-    if (cancel_fade)
-        cancel_fade();
-    if (cancel_rainbow)
-        cancel_rainbow();
-    if (cancel_timeout)
-        cancel_timeout();
+    s_reset();
 }

--- a/src/game_objects/essence.cpp
+++ b/src/game_objects/essence.cpp
@@ -153,7 +153,7 @@ void Essence::pickup_anim() {
 void Essence::setup_timeout() {
     // Make essence disappear after a while.
     int time_out = ESSENCE_TIME_OUT + (int)Util::random(-1000, 1000); // Slightly diff time outs
-    Timer::get()->do_after(
+    cancel_timeout = Timer::get()->do_after(
         std::chrono::milliseconds(time_out),
         [&]() mutable {
         // Tells client to start disappearing animation. This is the easiest way to send animation commands to client atm.
@@ -170,4 +170,26 @@ void Essence::disable_after_disappear() {
         [&]() {
         disable();
     });
+}
+
+// Disables everything on object
+void Essence::s_reset() {
+    disable();
+    if (cancel_fade)
+        cancel_fade();
+    if (cancel_rainbow)
+        cancel_rainbow();
+    if (cancel_timeout)
+        cancel_timeout();
+}
+
+// Disables everything on object
+void Essence::c_reset() {
+    disable();
+    if (cancel_fade)
+        cancel_fade();
+    if (cancel_rainbow)
+        cancel_rainbow();
+    if (cancel_timeout)
+        cancel_timeout();
 }

--- a/src/game_objects/essence.h
+++ b/src/game_objects/essence.h
@@ -18,6 +18,9 @@ public:
     void s_on_collision(GameObject *other) override;
     void c_on_collision(GameObject *other) override;
 
+    void s_reset() override;
+    void c_reset() override;
+
     void setup_model() override;
 
     void random_push();
@@ -29,6 +32,7 @@ private:
     std::unique_ptr<collectibles::Collectible> value;
 
     std::function<void()> cancel_fade;
+    std::function<void()> cancel_timeout;
     std::function<void()> cancel_rainbow; // Cancels the constant rainbow color changing
 
     bool disappearing;

--- a/src/game_objects/game_object.cpp
+++ b/src/game_objects/game_object.cpp
@@ -93,7 +93,11 @@ void GameObject::c_update() {
 }
 
 void GameObject::c_update_state(glm::mat4 mat, bool enab) {
-    enabled = enab;
+    if (enab)
+        enable();
+    else
+        disable();
+
     if (enabled) {
         transform.set_world_mat(mat);
         set_rb_transform();

--- a/src/game_objects/player.cpp
+++ b/src/game_objects/player.cpp
@@ -17,7 +17,7 @@
 
 std::vector<std::string> Player::PLAYER_MODELS = { "boy_two", "lizard", "cat", "tomato" };
 
-Player::Player(int id) : GameObject(id), is_client(false), momentum(false), sumo(false) {
+Player::Player(int id) : GameObject(id), is_client(false), momentum(false), sumo(false), cancel_flicker([]() {}), cancel_invulnerable([]() {}), cancel_slow([]() {}), cancel_stun([]() {}) {
     tag = "PLAYER";
 
     if (id == ON_SERVER) {
@@ -284,12 +284,9 @@ void Player::c_take_damage() {
     end_flicker = false;
 
     // Make sure all animations from previous cycle has ended
-    if (cancel_flicker)
-        cancel_flicker();
-    if (cancel_stun)
-        cancel_stun();
-    if (cancel_invulnerable)
-        cancel_invulnerable();
+    cancel_flicker();
+    cancel_stun();
+    cancel_invulnerable();
 
     // Flicker
     cancel_flicker = Timer::get()->do_every(
@@ -327,8 +324,7 @@ void Player::c_take_damage() {
 }
 
 void Player::s_slow() {
-    if (cancel_slow)
-        cancel_slow();
+    cancel_slow();
 
     // Start off unable to move, then slowly regain movespeed
     move_speed = 0.2f;
@@ -350,8 +346,7 @@ void Player::s_slow() {
 }
 
 void Player::c_slow() {
-    if (cancel_slow)
-        cancel_slow();
+    cancel_slow();
 
     // Turn player blue
     model->reset_colors();

--- a/src/game_objects/traps/mobile_trap.cpp
+++ b/src/game_objects/traps/mobile_trap.cpp
@@ -3,7 +3,7 @@
 #include "util/util_bt.h"
 #include "timer.h"
 
-MobileTrap::MobileTrap(int x, int z, int id) : CollisionTrap(x, z, id) {
+MobileTrap::MobileTrap(int x, int z, int id) : CollisionTrap(x, z, id), cancel_timer([]() {}) {
 }
 
 // Moves forward
@@ -55,8 +55,7 @@ void MobileTrap::check_wall() {
 // Changes direction every interval.
 void MobileTrap::setup_timer(long long time_interval_ms) {
     // cancels any previous timer, if exists.
-    if (cancel_timer)
-        cancel_timer();
+    cancel_timer();
 
     cancel_timer = Timer::get()->do_every(
         std::chrono::milliseconds(time_interval_ms),

--- a/src/game_objects/traps/projectile.cpp
+++ b/src/game_objects/traps/projectile.cpp
@@ -7,7 +7,7 @@
 #include "util/util.h"
 #include <iostream>
 
-Projectile::Projectile(int id) : GameObject(id) {
+Projectile::Projectile(int id) : GameObject(id), cancel_timer([]() {}) {
     if (id == ON_SERVER) {
         notify_on_collision = true;
     }
@@ -63,8 +63,7 @@ void Projectile::handle_movement() {
 
 void Projectile::setup_timer() {
     // cancels any previous timer, if exists.
-    if (cancel_timer)
-        cancel_timer();
+    cancel_timer();
 
     // Disable object if it times_out
     cancel_timer = Timer::get()->do_after(

--- a/src/game_objects/traps/projectile_trap.cpp
+++ b/src/game_objects/traps/projectile_trap.cpp
@@ -5,7 +5,7 @@
 
 #define MAX_PROJECTILES 5
 
-ProjectileTrap::ProjectileTrap(int x, int z, int id) : Trap(x, z, id) {
+ProjectileTrap::ProjectileTrap(int x, int z, int id) : Trap(x, z, id), cancel_timer([]() {}) {
     can_shoot = true;
 }
 
@@ -29,8 +29,7 @@ void ProjectileTrap::raycast_check() {
 // Setup to shoot every interval
 void ProjectileTrap::setup_timer(long long time_interval_ms) {
     // cancels any previous timer, if exists.
-    if (cancel_timer)
-        cancel_timer();
+    cancel_timer();
 
     // TODO : Figure out why trap does not shoot out at proper intervals
     cancel_timer = Timer::get()->do_every(

--- a/src/game_objects/traps/projectile_trap.cpp
+++ b/src/game_objects/traps/projectile_trap.cpp
@@ -68,7 +68,7 @@ void ProjectileTrap::fill_projectile_pool(ProjectileTypes type) {
 
 // Looks for an available projectile from pool, then shoots it
 void ProjectileTrap::shoot() {
-    if (!can_shoot || !enabled)
+    if (!(can_shoot && enabled))
         return;
 
     Projectile *to_shoot = nullptr;
@@ -110,8 +110,5 @@ void ProjectileTrap::s_reset() {
 }
 
 void ProjectileTrap::c_reset() {
-    // Disables all projectiles that are children
-    for (GameObject *proj : children)
-        proj->disable();
-    reset_to_initial_transform();
+    s_reset();
 }

--- a/src/game_objects/traps/projectile_trap.cpp
+++ b/src/game_objects/traps/projectile_trap.cpp
@@ -68,7 +68,7 @@ void ProjectileTrap::fill_projectile_pool(ProjectileTypes type) {
 
 // Looks for an available projectile from pool, then shoots it
 void ProjectileTrap::shoot() {
-    if (!can_shoot)
+    if (!can_shoot || !enabled)
         return;
 
     Projectile *to_shoot = nullptr;

--- a/src/game_objects/traps/projectile_trap.cpp
+++ b/src/game_objects/traps/projectile_trap.cpp
@@ -103,15 +103,15 @@ void ProjectileTrap::c_on_collision(GameObject*) {
 }
 
 void ProjectileTrap::s_reset() {
-    // Disables all projectiles in pool
-    for (Projectile *proj : projectile_pool) {
+    // Disables all projectiles that are children
+    for (GameObject *proj : children)
         proj->disable();
-    }
+    reset_to_initial_transform();
 }
 
 void ProjectileTrap::c_reset() {
-    // Disables all projectiles in pool
-    for (Projectile *proj : projectile_pool) {
+    // Disables all projectiles that are children
+    for (GameObject *proj : children)
         proj->disable();
-    }
+    reset_to_initial_transform();
 }

--- a/src/game_objects/traps/projectile_trap.cpp
+++ b/src/game_objects/traps/projectile_trap.cpp
@@ -101,3 +101,17 @@ void ProjectileTrap::shoot() {
 void ProjectileTrap::c_on_collision(GameObject*) {
     play_trigger_animation();
 }
+
+void ProjectileTrap::s_reset() {
+    // Disables all projectiles in pool
+    for (Projectile *proj : projectile_pool) {
+        proj->disable();
+    }
+}
+
+void ProjectileTrap::c_reset() {
+    // Disables all projectiles in pool
+    for (Projectile *proj : projectile_pool) {
+        proj->disable();
+    }
+}

--- a/src/game_objects/traps/projectile_trap.h
+++ b/src/game_objects/traps/projectile_trap.h
@@ -39,8 +39,10 @@ protected:
 public:
     ProjectileTrap(int x, int z, int id = 0);
 
-  
-  virtual void s_update_this() override;
+    virtual void s_update_this() override;
 
-  void c_on_collision(GameObject* other) override;
+    void c_on_collision(GameObject* other) override;
+
+    void s_reset() override;
+    void c_reset() override;
 };


### PR DESCRIPTION
Disables all leftover objects in the previous dungeon phase at the start of the build phase, preventing essence and arrows from previous rounds to cross over.

Also fixes bug with arrow rigid bodies persisting into the mini game phase. 