### PR TITLE
Delayed goal spawning

### DIFF
--- a/src/events.cpp
+++ b/src/events.cpp
@@ -126,6 +126,7 @@ namespace events {
         signal<void()> post_dungeon_camera_event;
         signal<void(float, float)> s_spawn_essence_event;
         signal<void(float, float, int)> c_spawn_essence_event;
+        signal<void()> s_create_goal;
     }
 
     namespace minigame {

--- a/src/events.h
+++ b/src/events.h
@@ -342,6 +342,9 @@ namespace events {
         // Spawns a Dream Essence object
         extern signal<void(float, float)> s_spawn_essence_event; // Server
         extern signal<void(float, float, int)> c_spawn_essence_event; // Client
+
+        // Create goal on server.
+        extern signal<void()> s_create_goal;
     }
 
     namespace minigame {

--- a/src/game/phase/dungeon.cpp
+++ b/src/game/phase/dungeon.cpp
@@ -5,6 +5,7 @@
 #include "game_objects/essence.h"
 #include "game_objects/traps/mobile_trap.h"
 #include "audio/audio_manager.h"
+#include "timer.h"
 
 std::string DungeonPhase::to_string() {
     return "DUNGEON PHASE";
@@ -22,6 +23,11 @@ void DungeonPhase::s_setup() {
     });
 
     events::dungeon::s_prepare_dungeon_event();
+
+    // Start timer to spawn delayed goal.
+    Timer::get()->do_after(std::chrono::seconds(30), []() {
+        events::dungeon::s_create_goal();
+    });
 
     essence_conn = events::dungeon::s_spawn_essence_event.connect([&](float x, float z) {
         Essence *ess = new Essence();
@@ -94,7 +100,7 @@ void DungeonPhase::c_setup() {
                 context.player_finished = true;
                 events::dungeon::post_dungeon_camera_event();
             } else {
-                events::ui::show_notification("Someone reached the goal!", 1);
+                events::ui::show_notification("Someone reached the exit!", 1);
             }
         });
 

--- a/src/scene/main_scene.cpp
+++ b/src/scene/main_scene.cpp
@@ -70,17 +70,22 @@ void MainScene::connect_listeners() {
 
     dungeon_conn = events::dungeon::s_prepare_dungeon_event.connect([&]() {
         remove_goal();
+    });
+
+    delayed_goal_conn = events::dungeon::s_create_goal.connect([&]() {
         s_place_goal(glm::vec3(0.0f), 20);
     });
 
     goal_conn = events::dungeon::spawn_existing_goal_event.connect([&](int x, int z, int id) {
         c_place_goal(x, z, id);
+        events::ui::show_notification("The exit has appeared!", 5.f);
     });
 }
 
 void MainScene::disconnect_listeners() {
     build_conn.disconnect();
     dungeon_conn.disconnect();
+    delayed_goal_conn.disconnect();
     goal_conn.disconnect();
 }
 

--- a/src/scene/main_scene.h
+++ b/src/scene/main_scene.h
@@ -26,6 +26,7 @@ private:
 
     boost::signals2::connection build_conn;
     boost::signals2::connection dungeon_conn;
+    boost::signals2::connection delayed_goal_conn;
     boost::signals2::connection goal_conn;
 public:
     MainScene();


### PR DESCRIPTION
- goal now spawns 30 seconds into the dungeon phase
- someone may want to add a debug key to force the goal to spawn, but idk how multiple goal placing would work. May need to call remove_goal().