### PR TITLE
Stop all music and sound effects in teardowns

### DIFF
--- a/src/audio/audio_manager.cpp
+++ b/src/audio/audio_manager.cpp
@@ -41,11 +41,6 @@ AudioManager::AudioManager() : muted(false), max_music_volume(100.0), max_sound_
     loadSounds();
 
     events::music_event.connect([&](const events::AudioData &d) {
-        // Stop the current music from playing, if any
-        if (music.getStatus() == sf::SoundSource::Status::Playing) {
-            music.stop();
-        }
-        
         std::string filename = d.filename;
         if (!music.openFromFile(filename)) {
             std::cerr << "AudioManager: Cannot open " << filename << std::endl;;
@@ -58,6 +53,10 @@ AudioManager::AudioManager() : muted(false), max_music_volume(100.0), max_sound_
         
         music.play();
     });
+
+	events::stop_all_sounds_event.connect([&]() {
+		music.stop();
+	});
 
     events::sound_effects_event.connect([&](const events::AudioData &d) {
         std::string filename = d.filename;
@@ -84,7 +83,7 @@ AudioManager::AudioManager() : muted(false), max_music_volume(100.0), max_sound_
         active_sounds[inactive_sound_index].play();
     });
 
-    events::stop_all_sounds.connect([&]() {
+    events::stop_all_sounds_event.connect([&]() {
         for (int i = 0; i < active_sounds.size(); i++) {
             active_sounds[i] = sf::Sound();
         }

--- a/src/audio/audio_manager.cpp
+++ b/src/audio/audio_manager.cpp
@@ -54,9 +54,9 @@ AudioManager::AudioManager() : muted(false), max_music_volume(100.0), max_sound_
         music.play();
     });
 
-	events::stop_all_sounds_event.connect([&]() {
-		music.stop();
-	});
+    events::stop_all_sounds_event.connect([&]() {
+        music.stop();
+    });
 
     events::sound_effects_event.connect([&](const events::AudioData &d) {
         std::string filename = d.filename;

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -6,8 +6,9 @@ namespace events {
     signal<void(const ButtonData &)> button_event;
     signal<void(const StickData &)> stick_event;
     signal<void(const AudioData &)> music_event;
+	signal<void()> stop_music_event;
     signal<void(const AudioData &)> sound_effects_event;
-    signal<void()> stop_all_sounds;
+    signal<void()> stop_all_sounds_event;
     signal<void()> toggle_mute_event;
     signal<void(WindowSizeData &)> window_buffer_resize_event;
     signal<void(WindowKeyData &)> window_key_event;

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -6,7 +6,7 @@ namespace events {
     signal<void(const ButtonData &)> button_event;
     signal<void(const StickData &)> stick_event;
     signal<void(const AudioData &)> music_event;
-	signal<void()> stop_music_event;
+    signal<void()> stop_music_event;
     signal<void(const AudioData &)> sound_effects_event;
     signal<void()> stop_all_sounds_event;
     signal<void()> toggle_mute_event;

--- a/src/events.h
+++ b/src/events.h
@@ -76,9 +76,10 @@ namespace events {
             distance = glm::distance(p->transform.get_position(), o->transform.get_position());
         }
     };
-    extern signal<void(const AudioData &)> music_event;
+	extern signal<void(const AudioData &)> music_event;
+	extern signal<void()> stop_music_event;
     extern signal<void(const AudioData &)> sound_effects_event;
-    extern signal<void()> stop_all_sounds;
+    extern signal<void()> stop_all_sounds_event;
     extern signal<void()> toggle_mute_event;
 
     struct WindowSizeData {

--- a/src/game/minigame/mg_pump.h
+++ b/src/game/minigame/mg_pump.h
@@ -35,6 +35,6 @@ private:
 
     std::vector<Player*> team1;
     std::vector<Player*> team2;
-	int team1_points;
-	int team2_points;
+    int team1_points;
+    int team2_points;
 };

--- a/src/game/phase/build.cpp
+++ b/src/game/phase/build.cpp
@@ -255,9 +255,9 @@ void BuildPhase::c_teardown() {
 
     events::build::end_build_event();
 
-	// Stop all music/sounds
-	events::stop_music_event();
-	events::stop_all_sounds_event();
+    // Stop all music/sounds
+    events::stop_music_event();
+    events::stop_all_sounds_event();
 }
 
 proto::Phase BuildPhase::s_phase_when_done() {

--- a/src/game/phase/build.cpp
+++ b/src/game/phase/build.cpp
@@ -254,6 +254,10 @@ void BuildPhase::c_teardown() {
     c_check_funds_conn.disconnect();
 
     events::build::end_build_event();
+
+	// Stop all music/sounds
+	events::stop_music_event();
+	events::stop_all_sounds_event();
 }
 
 proto::Phase BuildPhase::s_phase_when_done() {

--- a/src/game/phase/dungeon.cpp
+++ b/src/game/phase/dungeon.cpp
@@ -178,7 +178,9 @@ void DungeonPhase::c_teardown() {
     essence_conn.disconnect();
     player_finish_conn.disconnect();
 
-    events::stop_all_sounds();
+	// Stop all music/sounds
+	events::stop_music_event();
+    events::stop_all_sounds_event();
 }
 
 proto::Phase DungeonPhase::s_phase_when_done() {

--- a/src/game/phase/dungeon.cpp
+++ b/src/game/phase/dungeon.cpp
@@ -178,8 +178,8 @@ void DungeonPhase::c_teardown() {
     essence_conn.disconnect();
     player_finish_conn.disconnect();
 
-	// Stop all music/sounds
-	events::stop_music_event();
+    // Stop all music/sounds
+    events::stop_music_event();
     events::stop_all_sounds_event();
 }
 

--- a/src/game/phase/menu.cpp
+++ b/src/game/phase/menu.cpp
@@ -28,12 +28,12 @@ void MenuPhase::c_setup() {
             }
             case events::BTN_LB: {
                 events::menu::c_cycle_player_model_event(false);
-				events::sound_effects_event(events::AudioData(AudioManager::SELECT1_SOUND, false));
+                events::sound_effects_event(events::AudioData(AudioManager::SELECT1_SOUND, false));
                 break;
             }
             case events::BTN_RB: {
                 events::menu::c_cycle_player_model_event(true);
-				events::sound_effects_event(events::AudioData(AudioManager::SELECT1_SOUND, false));
+                events::sound_effects_event(events::AudioData(AudioManager::SELECT1_SOUND, false));
                 break;
             }
             default:

--- a/src/game/phase/minigame_phase.cpp
+++ b/src/game/phase/minigame_phase.cpp
@@ -53,8 +53,8 @@ void MinigamePhase::c_setup() {
         events::ui::show_notification(curr_mg->get_info().objective, 5);
     });
 
-	events::sound_effects_event(events::AudioData(AudioManager::WHOOSH_SOUND, false));
-	events::music_event(events::AudioData(AudioManager::BUILD_MUSIC, true));  // Need to change to mini game music
+    events::sound_effects_event(events::AudioData(AudioManager::WHOOSH_SOUND, false));
+    events::music_event(events::AudioData(AudioManager::BUILD_MUSIC, true));  // Need to change to mini game music
 
     events::ui::show_countdown({"3", "2", "1", "GO"}, [this]() {
         input::ModalInput::get()->set_mode(input::ModalInput::NORMAL);
@@ -100,9 +100,9 @@ void MinigamePhase::c_teardown() {
     events::ui::dismiss_legend();
     events::minigame::end_minigame_event();
 
-	// Stop all music/sounds
-	events::stop_music_event();
-	events::stop_all_sounds_event();
+    // Stop all music/sounds
+    events::stop_music_event();
+    events::stop_all_sounds_event();
 }
 
 proto::Phase MinigamePhase::s_phase_when_done() {

--- a/src/game/phase/minigame_phase.cpp
+++ b/src/game/phase/minigame_phase.cpp
@@ -99,6 +99,10 @@ void MinigamePhase::c_teardown() {
     curr_mg->c_teardown();
     events::ui::dismiss_legend();
     events::minigame::end_minigame_event();
+
+	// Stop all music/sounds
+	events::stop_music_event();
+	events::stop_all_sounds_event();
 }
 
 proto::Phase MinigamePhase::s_phase_when_done() {

--- a/src/scene/minigame_scenes/mgscene_pump.h
+++ b/src/scene/minigame_scenes/mgscene_pump.h
@@ -14,7 +14,7 @@ private:
     std::vector<Pump*> pumps;
     std::map<int, Pump*> pump_map;
     std::vector<HotAirBasket*> baskets;
-	std::vector<HotAirBalloon*> balloons;
+    std::vector<HotAirBalloon*> balloons;
     int player_count;
 public:
     MGScenePump();
@@ -26,5 +26,5 @@ public:
     void disconnect_listeners() override;
     void reset_camera() override;
     void reset_scene() override;
-	void inflate_balloon(bool is_team1);
+    void inflate_balloon(bool is_team1);
 };

--- a/src/ui/clock_ui.cpp
+++ b/src/ui/clock_ui.cpp
@@ -27,7 +27,7 @@ ClockUI::ClockUI(float aspect, int rounds)
     float padding = 0.2f;
     float round_height = 2.f;
     float round_width = (20.f * aspect - (rounds + 1) * padding) / rounds;
-	
+    
     // Create a UI rectangle for each round. Will set color when that round is reached.
     for (int i = 0; i < rounds; ++i) {
         UIRectangle* round_seg = new UIRectangle(0, padding, // start coordinates

--- a/src/ui/ui_grid.cpp
+++ b/src/ui/ui_grid.cpp
@@ -111,8 +111,8 @@ void UIGrid::toggle_current_selection_halo() {
 
 void UIGrid::move_selection(Direction d) {
     toggle_current_selection_halo();
-	int old_selection_row = selection_row;
-	int old_selection_col = selection_col;
+    int old_selection_row = selection_row;
+    int old_selection_col = selection_col;
 
     switch (d) {
         case Direction::UP:
@@ -131,9 +131,9 @@ void UIGrid::move_selection(Direction d) {
             break;
     }
 
-	if ((selection_row != old_selection_row) || (selection_col != old_selection_col)) {
-		events::sound_effects_event(events::AudioData(AudioManager::SELECT1_SOUND, false));
-	}
+    if ((selection_row != old_selection_row) || (selection_col != old_selection_col)) {
+        events::sound_effects_event(events::AudioData(AudioManager::SELECT1_SOUND, false));
+    }
 
     toggle_current_selection_halo();
 }


### PR DESCRIPTION
Teardowns for phases are now responsible for stopping all music and sound effects.

Renamed events::stop_all_sounds() -> events::stop_all_sounds_event()