### PR TITLE
Cleanup Dungeon

### DIFF
--- a/src/game/phase/dungeon.cpp
+++ b/src/game/phase/dungeon.cpp
@@ -173,6 +173,11 @@ void DungeonPhase::s_teardown() {
             stats.add_coins(rewards[kv.second]);
         });
     }
+
+    // Resets all game objects
+    for (auto & kv : GameObject::game_objects) {
+        kv.second->s_reset();
+    }
 }
 
 void DungeonPhase::c_teardown() {
@@ -185,8 +190,17 @@ void DungeonPhase::c_teardown() {
     // Stop all music/sounds
     events::stop_music_event();
     events::stop_all_sounds_event();
+
     // Stop goal buzzing.
     events::dungeon::disable_goal_buzz();
+
+    // Resets game objects on client side
+    for (auto & kv : GameObject::game_objects) {
+        if (!kv.second) continue;
+        if (dynamic_cast<Player*>(kv.second))
+            kv.second->disable();
+        kv.second->c_reset();
+    }
 }
 
 proto::Phase DungeonPhase::s_phase_when_done() {

--- a/src/game_objects/player.cpp
+++ b/src/game_objects/player.cpp
@@ -200,6 +200,7 @@ void Player::s_reset() {
     stunned = false;
     confused = false;
     move_speed = BASE_MOVE_SPEED;
+	momentum = false;
 }
 
 void Player::c_reset() {
@@ -212,7 +213,7 @@ void Player::c_reset() {
     invulnerable = false;
     stunned = false;
     confused = false;
-    events::ui::hide_effect_image(0.0f);
+    events::ui::hide_effect_image(0.1f);
     disable_filter();
     model->reset_colors();
 }

--- a/src/game_objects/player.cpp
+++ b/src/game_objects/player.cpp
@@ -189,6 +189,35 @@ void Player::s_on_collision(GameObject *other) {
 void Player::c_on_collision(GameObject *other) {
 }
 
+void Player::s_reset() {
+    cancel_flicker();
+    cancel_stun();
+    cancel_invulnerable();
+    cancel_slow();
+    cancel_confuse();
+    end_flicker = true;
+    invulnerable = false;
+    stunned = false;
+    confused = false;
+    move_speed = BASE_MOVE_SPEED;
+}
+
+void Player::c_reset() {
+    cancel_flicker();
+    cancel_stun();
+    cancel_invulnerable();
+    cancel_slow();
+    cancel_confuse();
+    end_flicker = true;
+    invulnerable = false;
+    stunned = false;
+    confused = false;
+    events::ui::hide_effect_image(0.0f);
+    disable_filter();
+    model->reset_colors();
+}
+
+
 void Player::set_start_position(glm::vec3 pos) {
     initial_transform.set_position(pos);
 }

--- a/src/game_objects/player.h
+++ b/src/game_objects/player.h
@@ -60,6 +60,9 @@ public:
     void s_on_collision(GameObject *other) override;
     void c_on_collision(GameObject *other) override;
 
+    void s_reset() override;
+    void c_reset() override;
+
     void c_setup_player_model(int index); // Loads player model
 
     bool get_exiting_status() { return exiting; };


### PR DESCRIPTION
Calls game object's reset functions on dungeon phase teardown, most notably Player's in order to remove all lingering status effects. 